### PR TITLE
Update package.json traceur issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "rsvp": "~3.0.3",
     "semver": "~2.1.0",
     "systemjs-builder": "0.0.5",
-    "traceur": "git+ssh://git@github.com/google/traceur-compiler.git",
+    "traceur": "0.0.42",
     "uglify-js": "~2.4.10"
   },
   "devDependencies": {


### PR DESCRIPTION
The traceur dependencies was not letting npm install traceur thus not being able to install jspm.
