### PR TITLE
send a non-zero exit code if script terminates early

### DIFF
--- a/jspm.js
+++ b/jspm.js
@@ -133,7 +133,7 @@ if (require.main !== module)
         // something happened (cancel / err)
         ui.log('err', err.stack || err);
         ui.log('warn', 'Installation changes not saved');
-        process.exit();
+        process.exit(1);
       });
 
     break;
@@ -147,7 +147,7 @@ if (require.main !== module)
       }, function(err) {
         ui.log('err', err.stack || err);
         ui.log('warn', 'Update changes not saved');
-        process.exit();
+        process.exit(1);
       });
 
     break;
@@ -164,7 +164,7 @@ if (require.main !== module)
       }, function(err) {
         ui.log('err', err.stack || err);
         ui.log('warn', 'Uninstall changes not saved');
-        process.exit();
+        process.exit(1);
       });
     break;
 


### PR DESCRIPTION
The default behaviour for process.exit() sends an exit code of 0. This PR sends an exit code of 1 in the cases of error to indicate when the script has failed to complete
