### PR TITLE
Minor fix: jspm fails without exit code when github ratelimit hit

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -44,6 +44,10 @@ var log = exports.log = function(type, msg) {
     msg = type;
     type = null;
   }
+
+  if (typeof(msg) !== 'string')
+    msg = String(msg);
+
   if (type)
     msg = format[type](msg);
 


### PR DESCRIPTION
Found that when the github ratelimit is hit, JSPM will throw a integer (403) instead of an error. This causes `ui.log('err', err.stack || err);` to throw, preventing `process.exit(1);`

From: [jspm.js#L128...L133](/jspm/jspm-cli/blob/master/jspm.js#L128...L133)

``` js
      }, function(err) {
        // something happened (cancel / err)
        ui.log('err', err.stack || err);
        ui.log('warn', 'Installation changes not saved');
        process.exit(1);
      });
```

The `ui.log` formatter at [lib/ui.js#L58](/jspm/jspm-cli/blob/master/lib/ui.js#L58) will fail, as the method `.replace` doesn't exist on a non-string object.

This patch fixes this by converting all error messages to String first.

Its critical for jspm to fail with `process.exit(1);` for our build process to fail, otherwise it will continue with our packages is an unexpected state.
