### PR TITLE
mapping workflow, first attempt

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -169,7 +169,7 @@ exports.load = function() {
     if (pjson.buildConfig)
       config.buildConfig = pjson.buildConfig;
 
-    config.name = pjson.name || 'app';
+    config.name = pjson.name || pjson.directories && pjson.directories.lib || 'app';
     config.main = pjson.main;
 
     if (pjson.dependencies) {
@@ -271,9 +271,53 @@ exports.load = function() {
           config.depMap[d][m] = new Package(depMap[m]);
       }
     }
-
+  })
+  .then(checkMapConfig)
+  .then(function() {
     config.loaded = true;
-  });
+  })
+}
+
+// checks to see if the package.json map config
+// is accurately reflected in the config file
+// - if the config file has a property not in the package.json, we set it in the package.json
+// - if the package.json has a property not in the config, we set it in the config
+// - where there is a conflict, we specifically ask which value to use
+function checkMapConfig() {
+  var conflictPromises = [];
+
+  if (config.map) {
+    var depMap = config.depMap[config.name] = config.depMap[config.name] || {};
+
+    // check everything in package.json is reflected in config
+    for (var d in config.map) (function(d) {
+      var curMap = config.map[d];
+      if (depMap[d] && depMap[d].exactName !== curMap) {
+        conflictPromises.push(ui.confirm('The config file has a mapping, `' + d + ' -> ' + depMap[d].exactName 
+          + '`, while in the %package.json% this is mapped to `' + curMap + '`. Update the package.json?')
+        .then(function(override) {
+          if (override)
+            config.map[d] = depMap[d].exactName;
+          else
+            depMap[d] = new Package(curMap);
+        }));
+      }
+      else if (!depMap[d]) {
+        depMap[d] = new Package(curMap);
+      }
+    })(d);
+
+    // check everything in config is reflected in package.json
+    for (var d in depMap) (function(d) {
+      // we've handled all package.json now
+      if (config.map[d])
+        return;
+
+      config.map[d] = depMap[d].exactName;
+    })(d);
+  }
+
+  return Promise.all(conflictPromises);
 }
 
 // create a new package.json file in the current directory
@@ -358,7 +402,22 @@ exports.save = function() {
   for (var d in config.baseMap)
     curConfig.map[d] = config.baseMap[d].exactName;
 
+  // ensure the package map is at the top
+  var name = config.name;
+  if (config.depMap[name]) {
+    curConfig.map[name] = curConfig.map[name] || {};
+    var curDep = config.depMap[name];
+    for (var dep in curDep) {
+      // the node core libs are an exception
+      if (dep == 'nodelibs')
+        continue;
+      curConfig.map[name][dep] = curDep[dep].exactName;
+    }
+  }
+
   for (var d in config.depMap) {
+    if (d == config.name)
+      continue;
     curConfig.map[d] = curConfig.map[d] || {};
     var curDep = config.depMap[d];
     for (var dep in curDep) {
@@ -519,6 +578,15 @@ exports.save = function() {
       if (seen.indexOf(d) == -1)
         delete dependencies[d];
     }
+
+    var map = pjson.map;
+    for (var d in config.map) {
+      if (map[d] != config.map[d])
+        map[d] = config.map[d];
+    }
+
+    if (hasProperties(map))
+      pjson.map = map;
 
     if (!config.prefix)
       pjson.registry = 'jspm';


### PR DESCRIPTION
This is a rough draft of a mapping workflow.

The idea is that when I am writing a package, say `thispackage`, I may want to have custom maps set up within that package that will transfer when it is published.

The way we can handle this is with the `package.json` map property, which is supported by jspm:

``` json
{
  "map": {
    "custom-path": "value"
  }
}
```

This PR propogates the above map configuration into the configuration file, supporting syncing between the package.json and config file values.
