### PR TITLE
Further fix for failure to detect .jspm directory on Windows

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -14,7 +14,7 @@
  *   limitations under the License.
  */
 
-exports.HOME = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
+exports.HOME = process.env.HOME || process.env.USERPROFILE || process.env.HOMEPATH;
 
 var ui = require('./ui');
 var fs = require('graceful-fs');

--- a/lib/package.js
+++ b/lib/package.js
@@ -437,7 +437,7 @@ exports.download = function(pkg, jspmPackages, options, preload) {
     });
 
   var downloadDir = path.resolve(jspmPackages, pkg.endpoint, pkg.exactPackage);
-  var cacheDir = path.resolve(process.env.HOME, '.jspm', 'packages', pkg.endpoint, pkg.exactPackage);
+  var cacheDir = path.resolve(config.HOME, '.jspm', 'packages', pkg.endpoint, pkg.exactPackage);
   var exactVersion, lastNamePart, main;
 
   var force = options.force;


### PR DESCRIPTION
Two related changes:
1. [config.js] On my WIndows 7 64-bit system, HOMEPATH will give the path to HOME without the drive letter, while USERPROFILE will return the path with the drive letter. USERPROFILE should take precedence so the code doesn't break when you're working on something other than C: drive.
2. [package.js] Switched over a stray `process.env.HOME` to `config.HOME`. This was preventing the program from working on Windows.
