### PR TITLE
feat(package): add important main file support

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -517,6 +517,7 @@ exports.processPackage = function(pkg, dir, pjson) {
 exports.createMain = function(pkg, pjson, downloadDir) {
   var lastNamePart, main;
   var mainPath;
+  var importantMain;
 
   return Promise.resolve()
 
@@ -524,6 +525,7 @@ exports.createMain = function(pkg, pjson, downloadDir) {
   .then(function() {
     lastNamePart = pkg.name.split('/').pop().split(':').pop();
     main = typeof pjson.main == 'string' && pjson.main;
+    importantMain = main[main.length - 1] === '!' && main;
 
     if (main) {
       if (main.substr(0, 2) == './')
@@ -536,7 +538,9 @@ exports.createMain = function(pkg, pjson, downloadDir) {
 
     // try the package.json main
     return new Promise(function(resolve, reject) {
-      mainPath = path.resolve(downloadDir, main.substr(main.length - 3, 3) != '.js' ? main + '.js' : main);
+      mainPath = path.resolve(downloadDir, importantMain ?
+        main.substr(0, main.length - 1) :
+        main.substr(main.length - 3, 3) != '.js' ? main + '.js' : main);
       fs.exists(mainPath, resolve);
     });
   })
@@ -562,6 +566,7 @@ exports.createMain = function(pkg, pjson, downloadDir) {
 
       // create the main pointer
       var mainFile = path.resolve(downloadDir, '../' + lastNamePart + '@' + pkg.version + '.js');
+      main = importantMain || main;
       return asp(fs.writeFile)(mainFile, getRedirectContents(detected.format, pkg.exactName + '/' + main));
     });
   });


### PR DESCRIPTION
Allow plugin mains to be exported if specified.

Following #234 jspm/registry#62

---

Example :

``` bash
jspm install select2 -o "{ main: 'select2.css\!' }"
```

Is now writing in `jspm_packages/github/ivaynberg/select2@x.y.z.js`

``` js
module.exports = require("github:ivaynberg/select2@3.5.2/select2.css!");
```

So importing `select2` trigger the css plugin and import the css file.
