### PR TITLE
chore(package): unlink error code EISDIR

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -435,7 +435,7 @@ exports.download = function(pkg, override, preload) {
         // in case it was linked, try and remove
         return asp(fs.unlink)(downloadDir)
         .catch(function(e) {
-          if (e.code == 'EPERM' || e.code == 'ENOENT')
+          if (e.code == 'EISDIR' || e.code == 'EPERM' || e.code == 'ENOENT')
             return;
           throw e;
         });


### PR DESCRIPTION
For me on node v0.10.33
The `fs.unlink` error code is **EISDIR** if it expected a file, but the given pathname was a directory .
