### PR TITLE
Make --version less verbose

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -101,10 +101,8 @@ process.on('uncaughtException', function(err) {
   }
 
   function showVersion() {
-    showHeader();
-    ui.log('\n'
-      + 'Version: ' + require('./package.json').version + '\n'
-      + (process.env.localJspm == 'true' ? 'Running against local jspm install.' : 'Running against global jspm install.') + '\n'
+    ui.log(require('./package.json').version + '\n'
+      + (process.env.localJspm == 'true' ? 'Running against local jspm install.' : 'Running against global jspm install.')
     );
   }
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -44,8 +44,6 @@ var log = exports.log = function(type, msg) {
   if (apiResolver)
     return apiResolver.emit('log', type, msg);
 
-  if (logged == false)
-    console.log('');
   logged = true;
   if (arguments.length == 1) {
     msg = type;


### PR DESCRIPTION
When calling "jspm --version" only the version number and the information if jspm is running against a global or local install gets now printed.

I've also removed the initial empty line that gets printed within the lib/ui.js when ui.log() gets called for the first time in order to make the console output look more like `npm -v` or `bower -v`

``` bash
$ npm -v
2.1.11
$ bower -v
1.3.12
$ jspm -v
0.9.0
Running against local jspm install.
```

I've tested also other commands to see if the console output looks strange if this initial empty line is missing but so far everything looked ok for me.

closes #300 
