### PR TITLE
Updated for compatibility with npm scoped packages

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -35,7 +35,7 @@ function assert(statement, name) {
 
 /*
  * Main install API wrapper
- * 
+ *
  * install('jquery')
  * install('jquery', {options})
  * install('jquery', 'github:components/jquery')
@@ -81,10 +81,16 @@ exports.install = function(targets, options) {
         // -> install jquery=jquery@1.2.3 / jquery=npm:jquery / jquery=github:components/jquery@1.2.3
         if (!target) {
           target = name;
-          if (name.indexOf(':') != -1)
+          if (name.indexOf(':') != -1) // remove endpoint
             name = name.split(':')[1];
-          name = name.split('@')[0];
-          name = name.split('/').pop();
+
+          if(name.indexOf('@') !== 0) {
+            name = name.split('@')[0];
+            name = name.split('/').pop();
+          }
+          else { // if the first character is @ then we are dealing with a scoped package so the first @ and any / must remain (but be URL escaped)
+            name = '@'+name.substr(1).split('@')[0];
+          }
         }
         // convert shortcut version-only form
         else if (target.indexOf('@') == -1 && target.indexOf(':') == -1)
@@ -114,7 +120,7 @@ exports.install = function(targets, options) {
  *  - Default  a. The new install tree is set to use exact latest versions of primaries,
  *                including for existing primaries.
  *                Secondaries tend to their latest ideal version.
- *             b. Forks within the new tree are deduped for secondaries by checking for 
+ *             b. Forks within the new tree are deduped for secondaries by checking for
  *                rollback of the higher version.
  *             c. Forks against the existing tree are handled by upgrading the existing
  *                tree, at both primary and secondary levels, with the secondary fork
@@ -129,9 +135,9 @@ exports.install = function(targets, options) {
  *             Forks against existing tree follow default behaviour.
  *             (this is `jspm update`)
  *
- * Lock and Latest can be combined, which won't do anything for existing 
+ * Lock and Latest can be combined, which won't do anything for existing
  * installs but will give latest secondaries on new installs.
- * 
+ *
  * Secondary installs are those with a parent.
  *
  * Seen allows correct completion with circular package installs
@@ -161,7 +167,7 @@ function install(name, target, options, seen) {
     // lock if necessary
     if (options.lock && (resolution = getInstalledMatch(target)))
       return Promise.resolve();
-    
+
     if (options.link)
       return link.lookup(target);
 
@@ -219,7 +225,7 @@ function install(name, target, options, seen) {
           }
         });
 
-      // c. Forks against the existing tree are handled by upgrading the existing tree, 
+      // c. Forks against the existing tree are handled by upgrading the existing tree,
       //    at both primary and secondary levels, with the secondary fork potentially rolling back as well.
       resolveForks(installed, name, options.parent, resolution, function(forkVersion, forkRanges) {
         if (options.latest && semver.compare(forkVersion, resolution.version) == 1)
@@ -243,7 +249,7 @@ function install(name, target, options, seen) {
 
           if (semver.compare(bestSecondaryRollback.version, forkVersion) == -1)
             bestSecondaryRollback = getLatestMatch(forkVersion);
-          
+
           if (semver.match(target.version, bestSecondaryRollback.version)) {
             consolidated = true;
             logResolution(installingResolves, resolution, bestSecondaryRollback);
@@ -271,7 +277,7 @@ function install(name, target, options, seen) {
     return Promise.resolve()
     .then(function() {
       if (options.link)
-        return link.symlink(resolution, downloadDeps);      
+        return link.symlink(resolution, downloadDeps);
 
       if (options.inject)
         return pkg.inject(resolution, downloadDeps);
@@ -318,7 +324,7 @@ function install(name, target, options, seen) {
       secondaryRanges[options.parent] = secondaryRanges[options.parent] || {};
       if (!secondaryRanges[options.parent][name])
         secondaryRanges[options.parent][name] = target.copy();
-      else 
+      else
         assert(secondaryRanges[options.parent][name].exactName == target.exactName, 'Currently installed dependency ranges of `' + options.parent + '` are not consistent - try removing jspm_packages (%' + secondaryRanges[options.parent][name].exactName + '% should be %' + target.exactName + '%)');
     }
   }
@@ -640,7 +646,7 @@ function loadExistingRange(name, parent, inject) {
       ui.log('warn', (parent ? '%' + parent + '% dependency %' : '%') + name + '% is not a specified dependency in the package.json.');
       return;
     }
-    
+
     _target = target.copy();
     // locate the target
     return pkg.locate(_target)
@@ -712,7 +718,7 @@ function showVersions(forks) {
     if (vList.indexOf(version) == -1)
       vList.push(version);
   }
-  
+
   Object.keys(installed.baseMap).forEach(function(dep) {
     addDep(installed.baseMap[dep]);
   });
@@ -756,7 +762,7 @@ function showVersions(forks) {
 
     ui.log('info', '  ' + paddingString + '%' + dep + '% ' + vList.join(' '));
   });
-  
+
   if (haveLinked) {
     ui.log('info', '\nBold versions are linked. To unlink use %jspm install --unlink [name]%.');
   }
@@ -772,7 +778,7 @@ exports.showVersions = showVersions;
  * This is purely a configuration operation (config.js)
  * that is, we are cleaning that which is not already present in the configuration file
  * The first operation we do is orphaning within the configuration file itself
- * the second operation we do is a full package listing of jspm_packages, 
+ * the second operation we do is a full package listing of jspm_packages,
  * and removal of that which is not represented in configuration
  *
  */
@@ -887,7 +893,7 @@ exports.uninstall = function(name) {
       ui.log('warn', 'Dependency %' + name + '% is not a primary install.');
       return;
     }
-    
+
     delete config.pjson.dependencies[name];
     delete installed.baseMap[name];
 


### PR DESCRIPTION
Again with the trailing whitespace trimming..! 

Here all that's happening differently is instead of splitting on '@' blindly it checks to see if the '@' is the first character or not. If it is, it's assumed that it's a scoped package but might contain another '@' for versioning.
