### PR TITLE
jspm.bundle() wasn't working when retriggered from a gulp watch

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -86,6 +86,8 @@ exports.bundle = function(moduleExpression, fileName, opts) {
 
   var operations = extractOperations(args);
 
+  systemBuilder.reset();
+
   return config.load()
   .then(function() {
     fileName = fileName || path.resolve(config.pjson.baseURL, 'build.js');


### PR DESCRIPTION
Artifacts of the previous build was preventing changes to be propagated, therefore I called systemBuilder.reset() to clean up before each bundle build.
