### PR TITLE
Fixes #348

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -576,7 +576,7 @@ exports.processPackage = function(pkg, dir, pjson, postload) {
   var endpoint = ep.load(pjson.registry != 'jspm' && pjson.registry || pkg.endpoint);
   var deps;
   var buildErrors = [];
-  var curDeps;
+  var curDeps = [];
 
   return Promise.resolve()
 
@@ -599,7 +599,7 @@ exports.processPackage = function(pkg, dir, pjson, postload) {
       buildErrors = buildErrors.concat(_buildErrors);
 
     // if we gained a new dependency, download it
-    if (pjson.dependencies && Object.keys(pjson.dependencies).length > (curDeps.length || 0)) {
+    if (pjson.dependencies && Object.keys(pjson.dependencies).length > curDeps.length) {
       var newDepMap = processDeps(pjson.dependencies, pjson.registry);
       // remove dependencies already downloaded
       Object.keys(newDepMap).forEach(function(dep) {


### PR DESCRIPTION
Fix for https://github.com/jspm/jspm-cli/issues/348 which currently prevents `jspm install` with 0.10.2 in certain conditions (no `endpoints.build`).