### PR TITLE
Support for jspm.overrides in package.json.

### DIFF
--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -213,6 +213,12 @@ PackageJSON.prototype.write = function() {
       if (this.originalPjson[p] === pjson[p])
         delete pjson[p];
     }
+
+    // keep original overrides
+    try {
+      pjson.overrides = this.originalPjson.jspm.overrides;
+    } catch(e) {}
+
     this.originalPjson.jspm = pjson;
   }
 

--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -215,9 +215,8 @@ PackageJSON.prototype.write = function() {
     }
 
     // keep original overrides
-    try {
+    if (this.originalPjson.jspm && this.originalPjson.jspm.overrides)
       pjson.overrides = this.originalPjson.jspm.overrides;
-    } catch(e) {}
 
     this.originalPjson.jspm = pjson;
   }

--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -93,6 +93,7 @@ PackageJSON.prototype.read = function(prompts) {
     self.name = pjson.name || defaults.name;
 
     self.registry = pjson.registry;
+    self.overrides = pjson.overrides;
     self.dependencies = {};
     // only read dependencies when combined with a registry property
     if (pjson.dependencies && pjson.registry) {
@@ -166,6 +167,10 @@ PackageJSON.prototype.write = function() {
   if (this.packages != defaults.packages)
     directories.packages = this.packages;
 
+  console.log('---------------------------------------------')
+  console.log('this', this)
+  console.log('---------------------------------------------')
+
   if (hasProperties(directories)) {
     for (var d in directories)
       directories[d] = winPath(path.relative(this.dir, directories[d]));
@@ -214,9 +219,8 @@ PackageJSON.prototype.write = function() {
         delete pjson[p];
     }
 
-    // keep original overrides
-    if (this.originalPjson.jspm && this.originalPjson.jspm.overrides)
-      pjson.overrides = this.originalPjson.jspm.overrides;
+    // save the original overrides
+    pjson.overrides = this.overrides;
 
     this.originalPjson.jspm = pjson;
   }

--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -167,10 +167,6 @@ PackageJSON.prototype.write = function() {
   if (this.packages != defaults.packages)
     directories.packages = this.packages;
 
-  console.log('---------------------------------------------')
-  console.log('this', this)
-  console.log('---------------------------------------------')
-
   if (hasProperties(directories)) {
     for (var d in directories)
       directories[d] = winPath(path.relative(this.dir, directories[d]));

--- a/lib/install.js
+++ b/lib/install.js
@@ -282,7 +282,15 @@ function install(name, target, options, seen) {
       if (options.inject)
         return pkg.inject(resolution, downloadDeps);
 
-      return pkg.download(resolution, options.override, options.unlink, downloadDeps);
+      var override;
+
+      try {
+        override = options.override || config.pjson.originalPjson.jspm.overrides[name];
+      } catch(e) {}
+
+      // TODO: compound the options.override onto the package.json override?
+
+      return pkg.download(resolution, override, options.unlink, downloadDeps);
     })
     .then(function(fresh) {
       resolution.fresh = fresh;


### PR DESCRIPTION
Here's a starting point. The command line override takes precedence. Now need to modify pkg.write() so it doesn't get removed from package.json.:wq