### PR TITLE
Lowres documentation

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -153,7 +153,11 @@ exports.bundle = function(moduleExpression, fileName, opts) {
   })
   .then(config.save)
   .then(function() {
-    ui.log('ok', 'Built into `' + path.relative(process.cwd(), fileName) + '`' + (opts.sourceMaps ? ' with source maps' : '') + ', ' + (opts.minify ? '' : 'un') + 'minified.');
+    var buildPath = path.relative(process.cwd(), fileName);
+    var resolution = opts.lowResSourceMaps ? 'low-res ' : '';
+    ui.log('ok', 'Built into `' + buildPath + '`' +
+      (opts.sourceMaps ? ' with ' + resolution + 'source maps' : '') + ', ' +
+      (opts.minify ? '' : 'un') + 'minified.');
   })
   .catch(function(e) {
     ui.log('err', e.stack || e);


### PR DESCRIPTION
Should really get `--highres-source-maps` into `jspm help` (along with the other cli options) too