### PR TITLE
add --no-mangle cli param for bundle and bundle-sfx command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -90,7 +90,7 @@ process.on('uncaughtException', function(err) {
       + '  setmode dev                      Switch to the app development folder\n'
       + '  setmode production               Switch to the app production folder\n'
       + '\n'
-      + 'jspm bundle moduleA + module/b [outfile] [--inject] [--skip-source-maps]\n'
+      + 'jspm bundle moduleA + module/b [outfile] [--minify] [--no-mangle] [--inject] [--skip-source-maps]\n'
       + 'jspm bundle-sfx app/main [outfile] Export bundle as a single self-executing script\n'
       + 'jspm unbundle                      Remove injected bundle configuration\n'
       + 'jspm depcache moduleName           Stores dep cache in config for flat pipelining\n'
@@ -297,11 +297,12 @@ process.on('uncaughtException', function(err) {
     break;
 
     case 'bundle':
-      var options = readOptions(args, ['--inject', '--yes', '--skip-source-maps', '--minify', '--hires-source-maps']);
+      var options = readOptions(args, ['--inject', '--yes', '--skip-source-maps', '--minify',  '--no-mangle', '--hires-source-maps']);
       if (options.yes)
         ui.useDefaults();
       options.sourceMaps = !options['skip-source-maps'];
       options.lowResSourceMaps = !options['hires-source-maps'];
+      options.mangle = !options['no-mangle'];
       var bArgs = options.args.splice(1);
 
       if (bArgs.length < 2) {
@@ -342,9 +343,10 @@ process.on('uncaughtException', function(err) {
 
     case 'b':
     case 'bundle-sfx':
-      var options = readOptions(args, ['--yes', '--skip-source-maps', '--minify', '--hires-source-maps']);
+      var options = readOptions(args, ['--yes', '--skip-source-maps', '--minify',  '--no-mangle', '--hires-source-maps']);
       options.sourceMaps = !options['skip-source-maps'];
       options.lowResSourceMaps = !options['hires-source-maps'];
+      options.mangle = !options['no-mangle'];
       if (options.yes)
         ui.useDefaults();
       var bArgs = options.args.splice(1);

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -153,7 +153,7 @@ exports.bundle = function(moduleExpression, fileName, opts) {
   })
   .then(config.save)
   .then(function() {
-    ui.log('ok', 'Built into `' + path.relative(process.cwd(), fileName) + '`' + (opts.sourceMaps ? ' with source maps' : '') + ', ' + (opts.minify ? '' : 'un') + 'minified.');
+    ui.log('ok', 'Built into `' + path.relative(process.cwd(), fileName) + '`' + (opts.sourceMaps ? ' with source maps' : '') + ', ' + (opts.minify ? '' : 'un') + 'minified' + ', ' + (opts.mangle ? '' : 'un') + 'mangled.');
   })
   .catch(function(e) {
     ui.log('err', e.stack || e);
@@ -197,7 +197,7 @@ exports.bundleSFX = function(moduleName, fileName, opts) {
   })
   .then(config.save)
   .then(function() {
-    ui.log('ok', 'Built into `' + path.relative(process.cwd(), fileName) + '`' + (opts.sourceMaps ? ' with source maps' : '') + ', ' + (opts.minify ? '' : 'un') + 'minified.');
+    ui.log('ok', 'Built into `' + path.relative(process.cwd(), fileName) + '`' + (opts.sourceMaps ? ' with source maps' : '') + ', ' + (opts.minify ? '' : 'un') + 'minified' + ', ' + (opts.mangle ? '' : 'un') + 'mangled.');
   })
   .catch(function(e) {
     ui.log('err', e.stack || e);


### PR DESCRIPTION
As a follow up to systemjs/builder#59 released with systemjs-builder 0.6.0 this PR exposes a `--no-mangle` param for the `jspm bundle` and `jspm bundle-sfx` commands.
This allows for bundling minified but unmangled packages.

To maintain BC, mangling defaults to `true` and is only `false` if `--no-mangle` is passed.
If `--minify` is not passed, this additional option has no effect.