### PR TITLE
Fixes jspm install for io.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "liftoff": "^2.0.0",
     "minimatch": "^2.0.1",
     "mkdirp": "~0.5.0",
-    "ncp": "^1.0.1",
+    "ncp": "stefanpenner/ncp#iojs-fix",
     "request": "^2.53.0",
     "rimraf": "~2.2.2",
     "rsvp": "~3.0.16",


### PR DESCRIPTION
This uses a temporary fork of ncp that does not do version checking. There is a [pending pull request](https://github.com/AvianFlu/ncp/issues/79) with the ncp author that has not yet been accepted.

This should temporarily fix an issue that came up while working on #410 where `jspm install` fails silently and erratically when using io.js. Eventually when the ncp PR is merged we'd want to switch back to semver.