### PR TITLE
Add a warning when bundle is called with no arguments

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -317,6 +317,10 @@ process.on('uncaughtException', function(err) {
       options.mangle = !options['no-mangle'];
       var bArgs = options.args.splice(1);
 
+      if (bArgs.length === 0) {
+        return ui.log('warn', 'You must provide at least one module as the starting point for bundling');
+      }
+
       if (bArgs.length < 2) {
         bundle.bundle(bArgs[0], undefined, options)
         .catch(function(e) {


### PR DESCRIPTION
I misunderstood the instructions for bundle and ran `jspm bundle` with nothing else, and got this error:

```
err  TypeError: Cannot call method 'split' of undefined
         at Object.exports.bundle (/Users/jackfranklin/.nvm/v0.10.36/lib/node_modules/jspm/lib/bundle.js:82:31)
```

Took me a moment to figure it out so thought I'd update so it warns instead. Let me know what you think!