### PR TITLE
added jshint linter and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{*.js,package.json,.travis.yml}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ testlibs/build.js
 testlibs/build.js.map
 .DS_Store
 testlibs/.DS_Store
+npm-debug.log

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,3 @@
+sandbox/**/*
+testlibs/**/*
+node_modules/**/*

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,88 @@
+{
+    "maxerr"        : 50,       // {int} Maximum error before stopping
+
+    // Enforcing
+    "bitwise"       : true,     // true: Prohibit bitwise operators (&, |, ^, etc.)
+    "camelcase"     : false,    // true: Identifiers must be in camelCase
+    "curly"         : false,    // true: Require {} for every new block or scope
+    "eqeqeq"        : true,    // true: Require triple equals (===) for comparison
+    "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
+    "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
+    "immed"         : true,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+    "indent"        : 2,        // {int} Number of spaces to use for indentation
+    "latedef"       : "nofunc", // true: Require variables/functions to be defined before being used
+    "newcap"        : true,    // true: Require capitalization of all constructor functions e.g. `new F()`
+    "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
+    "noempty"       : true,     // true: Prohibit use of empty blocks
+    "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
+    "nonew"         : true,    // true: Prohibit use of constructors for side-effects (without assignment)
+    "plusplus"      : false,    // true: Prohibit use of `++` & `--`
+    "quotmark"      : "single", // Quotation mark consistency:
+                                //   false    : do nothing (default)
+                                //   true     : ensure whatever is used is consistent
+                                //   "single" : require single quotes
+                                //   "double" : require double quotes
+    "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+    "unused"        : true,     // true: Require all defined variables be used
+    "strict"        : false,    // true: Requires all functions run in ES5 Strict Mode
+    "maxparams"     : false,    // {int} Max number of formal params allowed per function
+    "maxdepth"      : false,    // {int} Max depth of nested blocks (within functions)
+    "maxstatements" : false,    // {int} Max number statements per function
+    "maxcomplexity" : false,    // {int} Max cyclomatic complexity per function
+    "maxlen"        : false,    // {int} Max number of characters per line
+
+    // Relaxing
+    "asi"           : false,     // true: Tolerate Automatic Semicolon Insertion (no semicolons)
+    "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
+    "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
+    "eqnull"        : false,     // true: Tolerate use of `== null`
+    "es5"           : false,     // true: Allow ES5 syntax (ex: getters and setters)
+    "esnext"        : false,     // true: Allow ES.next (ES6) syntax (ex: `const`)
+    "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
+                                 // (ex: `for each`, multiple try/catch, function expression…)
+    "evil"          : true,      // true: Tolerate use of `eval` and `new Function()`
+    "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
+    "funcscope"     : false,     // true: Tolerate defining variables inside control statements
+    "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
+    "iterator"      : false,     // true: Tolerate using the `__iterator__` property
+    "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
+    "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
+    "laxcomma"      : false,     // true: Tolerate comma-first style coding
+    "loopfunc"      : false,     // true: Tolerate functions being defined in loops
+    "multistr"      : false,     // true: Tolerate multi-line strings
+    "noyield"       : false,     // true: Tolerate generator functions with no yield statement in them.
+    "notypeof"      : false,     // true: Tolerate invalid typeof operator values
+    "proto"         : false,     // true: Tolerate using the `__proto__` property
+    "scripturl"     : false,     // true: Tolerate script-targeted URLs
+    "shadow"        : false,     // true: Allows re-define variables later in code e.g. `var x=1; x=2;`
+    "sub"           : false,     // true: Tolerate using `[]` notation when it can still be expressed in dot notation
+    "supernew"      : false,     // true: Tolerate `new function () { ... };` and `new Object;`
+    "validthis"     : false,     // true: Tolerate using this in a non-constructor function
+
+    // Environments
+    "browser"       : false,    // Web Browser (window, document, etc)
+    "browserify"    : false,    // Browserify (node.js code in the browser)
+    "couch"         : false,    // CouchDB
+    "devel"         : false,    // Development/debugging (alert, confirm, etc)
+    "dojo"          : false,    // Dojo Toolkit
+    "jasmine"       : false,    // Jasmine
+    "jquery"        : false,    // jQuery
+    "mocha"         : true,     // Mocha
+    "mootools"      : false,    // MooTools
+    "node"          : true,     // Node.js
+    "nonstandard"   : false,    // Widely adopted globals (escape, unescape, etc)
+    "prototypejs"   : false,    // Prototype and Scriptaculous
+    "qunit"         : false,    // QUnit
+    "rhino"         : false,    // Rhino
+    "shelljs"       : false,    // ShellJS
+    "worker"        : false,    // Web Workers
+    "wsh"           : false,    // Windows Scripting Host
+    "yui"           : false,    // Yahoo User Interface
+
+    // Custom Globals
+    "globals"       : {
+       "Promise"    : true      // Avoid "redefinition of Promise" warning
+    },
+
+    "futurehostile" : true      // Avoid warning when using io.js or Node.js >= 0.12.0 that Promises are already defined
+}

--- a/api.js
+++ b/api.js
@@ -14,7 +14,6 @@
  *   limitations under the License.
  */
 
-var core = require('./lib/core');
 var install = require('./lib/install');
 var bundle = require('./lib/bundle');
 var ui = require('./lib/ui');
@@ -52,7 +51,7 @@ API.locate = function(name, parentName) {
   .then(function(address) {
     return address.substr(5);
   });
-}
+};
 
 /*
  * jspm.on('log', function(type, msg) { console.log(msg); });
@@ -71,7 +70,7 @@ ui.useDefaults();
 
 API.promptDefaults = function(_useDefaults) {
   ui.useDefaults(_useDefaults);
-}
+};
 
 /*
  * Installs a library in the current folder
@@ -87,8 +86,8 @@ API.promptDefaults = function(_useDefaults) {
  *
  */
 API.install = function(name, target, options) {
-  return install.install.apply(install, arguments);
-}
+  return install.install.apply(install, [name, target, options]);
+};
 
 /* Uninstalls a library in the current folder.
  * returns a promise
@@ -98,15 +97,15 @@ API.install = function(name, target, options) {
  *
  */
 API.uninstall = function(names) {
-  return install.uninstall.apply(install, arguments); 
-}
+  return install.uninstall.apply(install, [names]);
+};
 
 API.import = function(moduleName, parentName) {
   return API.configureLoader()
   .then(function() {
     return System.import(moduleName, { name: parentName });
   });
-}
+};
 
 // takes an optional config argument to configure
 // returns the loader instance
@@ -130,7 +129,7 @@ API.configureLoader = function(cfg) {
       System.config(cfg);
     return System;
   });
-}
+};
 
 
 /*
@@ -144,16 +143,16 @@ API.configureLoader = function(cfg) {
 // options.minify
 API.bundle = function(expression, fileName, options) {
   return bundle.bundle(expression, fileName, options);
-}
+};
 
-/* 
+/*
  * Creates a distributable script file that can be used entirely on its own independent of SystemJS and jspm.
  * returns a promise
  * options.minify, options.sourceMaps
  */
 API.bundleSFX = function(moduleName, fileName, options) {
-  return bundle.bundleSFX(moduleName, fileName, options)
-}
+  return bundle.bundleSFX(moduleName, fileName, options);
+};
 
 /*
  * Returns a jspm-configured SystemJS Builder class
@@ -167,5 +166,4 @@ API.newBuilder = function() {
     systemBuilder.config(cfg);
     return systemBuilder;
   });
-}
-
+};

--- a/lib/build.js
+++ b/lib/build.js
@@ -21,7 +21,6 @@ var glob = require('glob');
 var rimraf = require('rimraf');
 var traceur = require('traceur');
 var uglify = require('uglify-js');
-var config = require('./config');
 var path = require('path');
 var minimatch = require('minimatch');
 
@@ -35,17 +34,17 @@ exports.buildPackage = function(dir, pjson, isCDN) {
   .then(function() {
     if (!pjson.directories || !pjson.directories.dist)
       return;
-    
+
     return asp(fs.stat)(path.resolve(dir, pjson.directories.dist))
     .then(function(stats) {
       return stats && stats.isDirectory();
-    }, function(e) {
+    }, function() {
       return false;
     })
     .then(function(dist) {
       if (dist)
         return build.collapseLibDir(dir, pjson.directories.dist).then(function() { return true; });
-    })
+    });
   })
 
   // check if directories.lib exists, if so collapse
@@ -59,12 +58,12 @@ exports.buildPackage = function(dir, pjson, isCDN) {
     return asp(fs.stat)(path.resolve(dir, pjson.directories.lib))
     .then(function(stats) {
       return stats && stats.isDirectory();
-    }, function(e) {
+    }, function() {
       return false;
     })
     .then(function(dist) {
       if (dist)
-        return build.collapseLibDir(dir, pjson.directories.lib)
+        return build.collapseLibDir(dir, pjson.directories.lib);
     });
   })
 
@@ -82,27 +81,23 @@ exports.buildPackage = function(dir, pjson, isCDN) {
         alwaysIncludeFormat: isCDN
       });
   });
-}
-
-function inDir(fileName, dir, sep) {
-  return fileName.substr(0, dir.length) == dir && (sep === false || fileName.substr(dir.length - 1, 1) == path.sep);
-}
+};
 
 exports.filterIgnoreAndFiles = function(dir, ignore, files) {
 
   if (!ignore && !files)
     return Promise.resolve();
-  
+
   return asp(glob)(dir + path.sep + '**' + path.sep + '*')
   .then(function(allFiles) {
     var removeFiles = [];
-  
+
     allFiles.forEach(function(file) {
       var fileName = path.relative(dir, file).replace(/\\/g, '/');
 
       // if files, remove all files except those in the files list
       if (files && !files.some(function(keepFile) {
-        if (keepFile.substr(0, 2) == './')
+        if (keepFile.substr(0, 2) === './')
           keepFile = keepFile.substr(2);
 
         // this file is in a keep dir, or a keep file, don't exclude
@@ -113,7 +108,7 @@ exports.filterIgnoreAndFiles = function(dir, ignore, files) {
 
       // if ignore, ensure removed
       if (ignore && ignore.some(function(ignoreFile) {
-        if (ignoreFile.substr(0, 2) == './')
+        if (ignoreFile.substr(0, 2) === './')
           ignoreFile = ignoreFile.substr(2);
         // this file is in an ignore dir or an ignore file, ignore
         if (inDir(fileName, ignoreFile, false) || minimatch(fileName, ignoreFile))
@@ -125,21 +120,20 @@ exports.filterIgnoreAndFiles = function(dir, ignore, files) {
     // do removal
     return Promise.all(removeFiles.map(function(removeFile) {
       return asp(fs.unlink)(path.resolve(dir, removeFile)).catch(function(e) {
-        if (e.code == 'EPERM' || e.code == 'EISDIR' || e.code == 'ENOENT')
+        if (e.code === 'EPERM' || e.code === 'EISDIR' || e.code === 'ENOENT')
           return;
         throw e;
       });
     }));
   });
-}
-
+};
 
 exports.collapseLibDir = function(dir, subDir) {
-  if (subDir.substr(subDir.length - 1, 1) == '/')
+  if (subDir.substr(subDir.length - 1, 1) === '/')
     subDir = subDir.substr(0, subDir.length - 1);
 
   var tmpDir = path.resolve(dir, '..', '.tmp-' + dir.split(path.sep).pop());
-  
+
   // move subDir to tmpDir
   return asp(fs.rename)(dir + path.sep + subDir, tmpDir)
 
@@ -152,32 +146,38 @@ exports.collapseLibDir = function(dir, subDir) {
   .then(function() {
     return asp(fs.rename)(tmpDir, dir);
   });
-}
+};
 
+function inDir(fileName, dir, sep) {
+  return fileName.substr(0, dir.length) === dir && (sep === false || fileName.substr(dir.length - 1, 1) === path.sep);
+}
 
 function matchWithWildcard(matches, name) {
   var curMatch;
   var curMatchLength;
-  
+
   main:
   for (var p in matches) {
+    if (!matches.hasOwnProperty(p))
+      continue;
+
     var matchParts = p.split('/');
     var nameParts = name.split('/');
-    if (matchParts.length != nameParts.length)
+    if (matchParts.length !== nameParts.length)
       continue;
 
     var match;
 
     for (var i = 0; i < matchParts.length; i++) {
       // do wildcard matching on individual parts if necessary
-      if (matchParts[i].indexOf('*') != -1) {
+      if (matchParts[i].indexOf('*') !== -1) {
         if (!(match = nameParts[i].match(new RegExp(matchParts[i].replace(/([^*\w])/g, '\\$1').replace(/(\*)/g, '(.*)')))))
           continue main;
       }
-      else if (nameParts[i] != matchParts[i])
-        continue main;  
+      else if (nameParts[i] !== matchParts[i])
+        continue main;
     }
-  
+
     // least wildcards in match wins
     if (p.length >= curMatchLength)
       continue;
@@ -187,6 +187,7 @@ function matchWithWildcard(matches, name) {
   }
   return curMatch;
 }
+
 // return the number of prefix parts (separated by '/') matching the name
 // eg prefixMatchLength('jquery/some/thing', 'jquery') -> 1
 function prefixMatchLength(name, prefix) {
@@ -195,31 +196,34 @@ function prefixMatchLength(name, prefix) {
   if (prefixParts.length > nameParts.length)
     return 0;
   for (var i = 0; i < prefixParts.length; i++)
-    if (nameParts[i] != prefixParts[i])
+    if (nameParts[i] !== prefixParts[i])
       return 0;
   return prefixParts.length;
 }
 
 // while doing map, we also remove ".js" extensions where necessary
 function applyMap(_name, map, baseFile, removeJSExtensions) {
-  var name = _name;
+  var name = _name, pluginName;
 
-  if (name.indexOf('!') != -1) {
-    var pluginName = name.substr(name.indexOf('!') + 1);
+  if (name.indexOf('!') !== -1) {
+    pluginName = name.substr(name.indexOf('!') + 1);
     name = name.substr(0, name.length - pluginName.length - 1);
     pluginName = pluginName || name.substr(name.lastIndexOf('.') + 1);
     pluginName = applyMap(pluginName, map, baseFile, false) || pluginName;
   }
 
-  
+
   if (removeJSExtensions) {
-    if (name.substr(0, 2) == './' || name.split('/').length > 1) {
-      if (name.substr(name.length - 3, 3) == '.js')
+    if (name.substr(0, 2) === './' || name.split('/').length > 1) {
+      if (name.substr(name.length - 3, 3) === '.js')
         name = name.substr(0, name.length - 3);
     }
   }
 
   for (var m in map) {
+    if (!map.hasOwnProperty(m))
+      continue;
+
     var matchLength = prefixMatchLength(name, m);
     if (!matchLength)
       continue;
@@ -228,10 +232,10 @@ function applyMap(_name, map, baseFile, removeJSExtensions) {
 
     var toMap = map[m];
 
-    if (toMap.substr(0, 2) == './') {
+    if (toMap.substr(0, 2) === './') {
       // add .js in case of matching directory name
       toMap = path.relative(path.dirname(baseFile), toMap.substr(2) + '.js');
-      if (toMap.substr(0, 1) != '.')
+      if (toMap.substr(0, 1) !== '.')
         toMap = './' + toMap;
       // remove .js
       toMap = toMap.substr(0, toMap.length - 3);
@@ -243,7 +247,7 @@ function applyMap(_name, map, baseFile, removeJSExtensions) {
   if (pluginName)
     name += '!' + pluginName;
 
-  if (name != _name)
+  if (name !== _name)
     return name;
 }
 
@@ -273,10 +277,10 @@ function detectFormat(source) {
       var len = metaParts[i].length;
 
       var firstChar = metaParts[i].substr(0, 1);
-      if (metaParts[i].substr(len - 1, 1) == ';')
+      if (metaParts[i].substr(len - 1, 1) === ';')
         len--;
-    
-      if (firstChar != '"' && firstChar != "'")
+
+      if (firstChar !== '"' && firstChar !== '\'')
         continue;
 
       var metaString = metaParts[i].substr(1, metaParts[i].length - 3);
@@ -306,7 +310,7 @@ function detectFormat(source) {
 
   if (source.match(amdRegEx))
     return { format: 'amd' };
-  
+
   if (cjsRequireRegEx.exec(source) || cjsExportsRegEx.exec(source))
     return { format: 'cjs' };
 
@@ -336,22 +340,27 @@ exports.compileDir = function(dir, options) {
   // create the map config
   // convert jspm options.dependencies into a requirable form
   // and combine them into a new map object
-  var map = {};
+  var map = {}, optionsMap, optionsDependencies;
   if (options.map)
-    for (var m in options.map)
-      map[m] = options.map[m];
+    optionsMap = options.map;
+    for (var m in optionsMap)
+      if (optionsMap.hasOwnProperty(m))
+        map[m] = optionsMap[m];
 
   if (options.dependencies) {
-    for (var d in options.dependencies) {
+    optionsDependencies = options.dependencies;
+    for (var d in optionsDependencies) {
+      if (!optionsDependencies.hasOwnProperty(d))
+        continue;
       // custom map overrides dependency map
       if (map[d])
         continue;
 
-      var curDep = options.dependencies[d];
-      if (curDep.indexOf(':') != -1 || curDep.indexOf('@') != -1)
+      var curDep = optionsDependencies[d];
+      if (curDep.indexOf(':') !== -1 || curDep.indexOf('@') !== -1)
         map[d] = curDep;
 
-      else if (curDep && curDep != '*')
+      else if (curDep && curDep !== '*')
         map[d] = d + '@' + curDep;
       else
         map[d] = d;
@@ -372,7 +381,7 @@ exports.compileDir = function(dir, options) {
       var sourceMap;
 
       var format;
-      if (options.format && typeof options.format == 'string')
+      if (options.format && typeof options.format === 'string')
         format = options.format.toLowerCase();
 
       var relFile = path.relative(dir, file);
@@ -387,7 +396,7 @@ exports.compileDir = function(dir, options) {
         return asp(fs.readFile)(file)
         .then(function(source) {
           source += '';
-          
+
           return Promise.resolve()
           // add shim config if necessary
           .then(function() {
@@ -406,7 +415,7 @@ exports.compileDir = function(dir, options) {
             // NB backwards-compatible with shim.imports
             curShim.deps = curShim.deps || curShim.imports;
 
-            if (typeof curShim.deps == 'string')
+            if (typeof curShim.deps === 'string')
               curShim.deps = [curShim.deps];
 
             var depStr = '"format global";' + nl;
@@ -442,7 +451,7 @@ exports.compileDir = function(dir, options) {
               return;
             }
 
-            if (options.alwaysIncludeFormat || !format || detected.format != format) {
+            if (options.alwaysIncludeFormat || !format || detected.format !== format) {
               changed = true;
               source = '"format ' + (format || detected.format) + '";' + nl + source;
             }
@@ -453,7 +462,7 @@ exports.compileDir = function(dir, options) {
           // apply map config
           .then(function() {
             // ES6
-            if (format == 'es6') {
+            if (format === 'es6') {
               source = source.replace(es6DepRegEx, function(statement, start, type, str, singleString, doubleString) {
                 var name = singleString || doubleString;
                 var mapped = applyMap(name, map, relFile, options.removeJSExtensions);
@@ -467,13 +476,13 @@ exports.compileDir = function(dir, options) {
             }
 
             // AMD
-            else if (format == 'amd') {
+            else if (format === 'amd') {
               amdDefineRegEx.lastIndex = 0;
               var defineStatement = amdDefineRegEx.exec(source);
               if (defineStatement) {
                 if (!defineStatement[2])
                   return;
-                
+
                 var depArray = eval(defineStatement[2]);
                 depArray.map(function(name) {
                   var mapped = applyMap(name, map, relFile, options.removeJSExtensions);
@@ -490,7 +499,7 @@ exports.compileDir = function(dir, options) {
             }
 
             // CommonJS
-            else if (format == 'cjs') {
+            else if (format === 'cjs') {
               source = source.replace(cjsRequireRegEx, function(statement, singleString, doubleString) {
                 var name = singleString || doubleString;
                 name = name.substr(1, name.length - 2);
@@ -505,11 +514,10 @@ exports.compileDir = function(dir, options) {
             }
 
             // Global? (including shim?)
-            else {
-            }
+            // else {
+            // }
           })
 
-          
           // if changed, save these meta-updates into the original file
           .then(function() {
 
@@ -558,7 +566,7 @@ exports.compileDir = function(dir, options) {
 
             try {
               var ast = uglify.parse(source, { filename: path.basename(relFile.replace(/\.js$/, '.src.js')) });
-              
+
               ast.figure_out_scope();
 
               ast = ast.transform(uglify.Compressor({
@@ -580,7 +588,7 @@ exports.compileDir = function(dir, options) {
               source = ast.print_to_string({
                 ascii_only: true, // for some reason non-ascii broke esprima
                 comments: function(node, comment) {
-                  return comment.line == 1 && comment.col == 0;
+                  return comment.line === 1 && comment.col === 0;
                 },
                 source_map: source_map
               });
@@ -609,37 +617,25 @@ exports.compileDir = function(dir, options) {
             .then(function() {
               return asp(fs.writeFile)(file + '.map', sourceMap);
             });
-          })
+          });
         }, function(e) {
-          if (e.code == 'EISDIR')
+          if (e.code === 'EISDIR')
             return;
           else
             throw e;
         });
       }, function(e) {
         // rethrow an error that wasn't a file read error
-        if (e.code == 'EISDIR')
+        if (e.code === 'EISDIR')
           return;
         else
           throw e;
       });
-    }))
+    }));
   })
 
   // output of compile promise is any compile errors
   .then(function() {
     return compileErrors;
   });
-}
-
-
-
-
-
-
-
-
-
-
-
-
+};

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -39,13 +39,17 @@ exports.depCache = function(moduleName) {
     var traceTree = output.tree;
     moduleName = output.moduleName;
     var depCache = config.loader.depCache = config.loader.depCache || {};
-    for (var d in traceTree) {
-      var deps = traceTree[d].deps.map(function(dep) {
-        return traceTree[d].depMap[dep];
-      });
 
-      if (deps.length)
-        depCache[d] = deps;
+    function mapDeps(dep) {
+      return this.traceTree[this.d].depMap[dep];
+    }
+
+    for (var d in traceTree) {
+      if (traceTree.hasOwnProperty(d)) {
+        var deps = traceTree[d].deps.map(mapDeps, {d: d, traceTree: traceTree});
+        if (deps.length)
+          depCache[d] = deps;
+      }
     }
   })
   .then(config.save)
@@ -56,26 +60,6 @@ exports.depCache = function(moduleName) {
     ui.log('err', e.stack || e);
   });
 };
-
-function extractOperations(args) {
-  var operations = [];
-
-  for (var i = 1; i < args.length - 1; i = i + 2) {
-    var operator = args[i];
-    var moduleName = args[i + 1];
-
-    operations.push({
-      operator: operator,
-      moduleName: moduleName
-    });
-  }
-
-  return operations;
-}
-
-function extractBundleName(fileName) {
-  return path.relative(config.pjson.baseURL, fileName.replace(/\.js$/, '')).replace(/\\/g, '/');
-}
 
 // options.inject, options.sourceMaps, options.minify
 exports.bundle = function(moduleExpression, fileName, opts) {
@@ -119,9 +103,9 @@ exports.bundle = function(moduleExpression, fileName, opts) {
 
           var operatorFunction;
 
-          if (op.operator == '+')
+          if (op.operator === '+')
             operatorFunction = systemBuilder.addTrees;
-          else if (op.operator == '-')
+          else if (op.operator === '-')
             operatorFunction = systemBuilder.subtractTrees;
           else
             throw 'Unknown operator ' + op.operator;
@@ -213,10 +197,30 @@ exports.bundleSFX = function(moduleName, fileName, opts) {
   });
 };
 
+function extractOperations(args) {
+  var operations = [];
+
+  for (var i = 1; i < args.length - 1; i = i + 2) {
+    var operator = args[i];
+    var moduleName = args[i + 1];
+
+    operations.push({
+      operator: operator,
+      moduleName: moduleName
+    });
+  }
+
+  return operations;
+}
+
+function extractBundleName(fileName) {
+  return path.relative(config.pjson.baseURL, fileName.replace(/\.js$/, '')).replace(/\\/g, '/');
+}
+
 function removeExistingSourceMap(fileName) {
   return asp(fs.unlink)(fileName + '.map')
   .catch(function(e) {
-    if (e.code == 'ENOENT')
+    if (e.code === 'ENOENT')
       return;
     throw e;
   });

--- a/lib/common.js
+++ b/lib/common.js
@@ -21,29 +21,36 @@ var config = require('./config');
 
 // the opposite of extend
 // useful for setting default config
-function dprepend(a, b) {
+exports.dprepend = function dprepend(a, b) {
   for (var p in b) {
+    if (!b.hasOwnProperty(p))
+      continue;
+
     var val = b[p];
-    if (typeof val == 'object')
-      dprepend(a[p] = typeof a[p] == 'object' ? a[p] : {}, val);
+    if (typeof val === 'object')
+      dprepend(a[p] = typeof a[p] === 'object' ? a[p] : {}, val);
     else if (!(p in a))
       a[p] = val;
   }
   return a;
-}
-exports.dprepend = dprepend;
+};
 
 exports.extend = function(a, b) {
-  for (var p in b)
-    a[p] = b[p];
+  for (var p in b) {
+    if (b.hasOwnProperty(p)) {
+      a[p] = b[p];
+    }
+  }
   return a;
-}
+};
 
 function dextend(a, b) {
   for (var p in b) {
+    if (!b.hasOwnProperty(p))
+      continue;
     var val = b[p];
-    if (typeof val == 'object')
-      dextend(a[p] = typeof a[p] == 'object' ? a[p] : {}, val)
+    if (typeof val === 'object')
+      dextend(a[p] = typeof a[p] === 'object' ? a[p] : {}, val);
     else
       a[p] = val;
   }
@@ -57,27 +64,27 @@ exports.hasProperties = function(obj) {
       return true;
   }
   return false;
-}
+};
 
 exports.readJSON = function(file) {
   return asp(fs.readFile)(file)
   .then(function(pjson) {
     pjson = pjson.toString();
     // remove any byte order mark
-    if (pjson.substr(0, 1) == '\uFEFF')
+    if (pjson.substr(0, 1) === '\uFEFF')
       pjson = pjson.substr(1);
     try {
       return JSON.parse(pjson);
     }
     catch(e) {
-      throw "Error parsing package.json file " + file;
+      throw 'Error parsing package.json file ' + file;
     }
   }, function(err) {
     if (err.code === 'ENOENT')
       return {};
     throw err;
   });
-}
+};
 
 // given an object, create a new object with the properties ordered alphabetically
 exports.alphabetize = function(obj) {
@@ -86,28 +93,27 @@ exports.alphabetize = function(obj) {
     newObj[p] = obj[p];
   });
   return newObj;
-}
-
+};
 
 exports.getRedirectContents = function(format, main) {
-  if (format == 'es6')
+  if (format === 'es6')
     return 'export * from "' + main + '";';
-  
-  else if (format == 'cjs' || format == 'global')
+
+  else if (format === 'cjs' || format === 'global')
     return 'module.exports = require("' + main + '");';
 
-  else if (format == 'amd')
+  else if (format === 'amd')
     return 'define(["' + main + '"], function(main) {\n  return main;\n});';
 
-  else if (format == 'register')
-    return 'System.register(["' + main + '"], ' + 
-      'function($__export) {\n  return {  setters: [function(m) { for (var p in m) $__export(p, m[p]); }],  execute: function() {}  };\n});'
+  else if (format === 'register')
+    return 'System.register(["' + main + '"], ' +
+      'function($__export) {\n  return {  setters: [function(m) { for (var p in m) $__export(p, m[p]); }],  execute: function() {}  };\n});';
 
   else
     throw 'Unknown module format ' + format + '.';
-}
+};
 
 exports.stringify = function (subject) {
   // replace the LF used by `JSON.stringify` with the preferred new line
   return JSON.stringify(subject, null, 2).replace(/\n/g, config.newLine);
-}
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -53,7 +53,7 @@ exports.derivePackageConfig = function(pjson, override) {
     dpjson.registry = dpjson.registry || 'jspm';
 
   return dpjson;
-}
+};
 
 // package and loader configuration objects that are created
 exports.pjson = null;
@@ -65,14 +65,14 @@ exports.load = function(prompts) {
   if (loadPromise)
     return loadPromise;
 
-  return loadPromise = Promise.resolve()
+  loadPromise = Promise.resolve()
   .then(function() {
     if (!process.env.jspmConfigPath)
       return ui.confirm('Package.json file does not exist, create it?', true)
       .then(function(create) {
         if (!create)
           throw 'Operation aborted.';
-      })
+      });
   })
   .then(function() {
     config.pjsonPath = process.env.jspmConfigPath || path.resolve(process.cwd(), 'package.json');
@@ -83,7 +83,7 @@ exports.load = function(prompts) {
   .then(function(_prompts) {
     // package.json can indicate if we need to run config prompts for a new package
     prompts = prompts || _prompts;
-    
+
     if (fs.existsSync(config.pjson.configFile))
       return;
 
@@ -91,7 +91,7 @@ exports.load = function(prompts) {
     .then(function(create) {
       if (!create)
         throw 'Operation aborted.';
-      
+
       // ensure config folder exists
       return asp(mkdirp)(path.dirname(config.pjson.configFile));
     });
@@ -103,7 +103,9 @@ exports.load = function(prompts) {
   .then(function() {
     config.loaded = true;
   });
-}
+
+  return loadPromise;
+};
 
 var savePromise;
 exports.save = function() {
@@ -120,13 +122,14 @@ exports.save = function() {
   .then(function() {
     savePromise = undefined;
   });
-}
+};
 
 // checks to see if the package.json map config
 // is accurately reflected in the config file
 // - if the config file has a property not in the package.json, we set it in the package.json
 // - if the package.json has a property not in the config, we set it in the config
 // - where there is a conflict, we specifically ask which value to use
+/*
 function checkMapConfig() {
   var conflictPromises = [];
 
@@ -164,7 +167,7 @@ function checkMapConfig() {
           curMap = config.name + curMap.substr(1);
 
         if (depMap[d] && depMap[d].exactName !== curMap) {
-          return ui.confirm('The config file has a mapping, `' + d + ' -> ' + depMap[d].exactName 
+          return ui.confirm('The config file has a mapping, `' + d + ' -> ' + depMap[d].exactName
             + '`, while in the %package.json% this is mapped to `' + curMap + '`. Update the package.json?')
           .then(function(override) {
             if (override) {
@@ -192,8 +195,9 @@ function checkMapConfig() {
 
         config.map[d] = depMap[d].exactName;
       }));
-    })
+    });
   }
 
   return Promise.resolve();
 }
+*/

--- a/lib/config.js
+++ b/lib/config.js
@@ -65,7 +65,7 @@ exports.load = function(prompts) {
   if (loadPromise)
     return loadPromise;
 
-  loadPromise = Promise.resolve()
+  return (loadPromise = Promise.resolve()
   .then(function() {
     if (!process.env.jspmConfigPath)
       return ui.confirm('Package.json file does not exist, create it?', true)
@@ -102,9 +102,7 @@ exports.load = function(prompts) {
   })
   .then(function() {
     config.loaded = true;
-  });
-
-  return loadPromise;
+  }));
 };
 
 var savePromise;

--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -49,7 +49,7 @@ function Config(fileName) {
 }
 Config.prototype.read = function(prompts) {
   if (this.read_)
-    throw "Config already read";
+    throw 'Config already read';
   this.read_ = true;
 
   var self = this;
@@ -62,11 +62,17 @@ Config.prototype.read = function(prompts) {
     var System = {
       config: function(_cfg) {
         for (var c in _cfg) {
+          if (!_cfg.hasOwnProperty(c))
+            continue;
+
           var v = _cfg[c];
-          if (typeof v == 'object') {
+          if (typeof v === 'object') {
             cfg[c] = cfg[c] || {};
-            for (var p in v)
+            for (var p in v) {
+              if (!v.hasOwnProperty(p))
+                continue;
               cfg[c][p] = v[p];
+            }
           }
           else
             cfg[c] = v;
@@ -93,7 +99,7 @@ Config.prototype.read = function(prompts) {
     // NB deprecate cfg.parser with 0.11.0
     self.transpiler = cfg.transpiler || cfg.parser || 'traceur';
     // NB deprecate babel rename with 0.13
-    if (self.transpiler == '6to5')
+    if (self.transpiler === '6to5')
       self.transpiler = 'babel';
 
     // separate paths into endpoints and paths
@@ -105,7 +111,7 @@ Config.prototype.read = function(prompts) {
         var endpointPath = new EndpointPath(endpointName, cfg.paths[p]);
         self.endpoints[endpointName] = endpointPath;
         if (self.local === undefined) {
-          if (endpointPath.mode == 'local')
+          if (endpointPath.mode === 'local')
             self.local = true;
           else
             self.local = false;
@@ -126,26 +132,31 @@ Config.prototype.read = function(prompts) {
     self.baseMap = {};
     self.depMap = {};
     for (var d in cfg.map) {
-      if (typeof cfg.map[d] == 'string')
+      if (typeof cfg.map[d] === 'string')
         self.baseMap[d] = new PackageName(cfg.map[d]);
       else {
         var depMap = cfg.map[d];
         self.depMap[d] = {};
         for (var m in depMap)
-          self.depMap[d][m] = new PackageName(depMap[m]);
+          if (depMap.hasOwnProperty(m)) {
+            self.depMap[d][m] = new PackageName(depMap[m]);
+          }
       }
     }
 
     // ensure that everything in baseMap has a depMap, even if empty
-    for (var d in self.baseMap) {
-      var name = self.baseMap[d].exactName;
-      var depMap = self.depMap[name] = self.depMap[name] || {};
+    var baseMap = self.baseMap, exactName;
+    for (var n in baseMap) {
+      if (baseMap.hasOwnProperty(n)) {
+        exactName = baseMap[n].exactName;
+        self.depMap[exactName] = self.depMap[exactName] || {};
+      }
     }
 
     self.versions = self.versions || {};
     for (var v in cfg.versions) {
-      if (typeof cfg.versions[v] == 'string')
-        self.versions[v] = [cfg.versions[v]]
+      if (typeof cfg.versions[v] === 'string')
+        self.versions[v] = [cfg.versions[v]];
       else
         self.versions[v] = cfg.versions[v];
     }
@@ -171,33 +182,35 @@ Config.prototype.read = function(prompts) {
       self.transpiler = transpiler;
     });
   });
-}
+};
 
 Config.prototype.ensureEndpoint = function(endpointName, remote) {
-  if (typeof remote == 'undefined') {
+  var endpoints = this.endpoints;
+
+  if (typeof remote === 'undefined') {
     // detect the endpoint mode from the first endpoint
-    remote = false;
-    for (var e in this.endpoints) {
-      if (this.endpoints[e].mode == 'remote')
-        remote = true;
-      break;
+    var endpointKeys = Object.keys(endpoints);
+    if (endpointKeys.length > 0) {
+      remote = endpoints[endpointKeys[0]].mode === 'remote';
+    } else {
+      remote = false;
     }
   }
 
-  if (this.endpoints[endpointName]) {
+  if (endpoints[endpointName]) {
     if (remote)
-      this.endpoints[endpointName].setRemote();
+      endpoints[endpointName].setRemote();
     else
-      this.endpoints[endpointName].setLocal();
+      endpoints[endpointName].setLocal();
     return;
   }
 
-  var ep = this.endpoints[endpointName] = new EndpointPath(endpointName);
+  var ep = endpoints[endpointName] = new EndpointPath(endpointName);
   if (remote)
     ep.setRemote();
   else
     ep.setLocal();
-}
+};
 
 // return the loader configuration for a server loading use
 Config.prototype.getConfig = function() {
@@ -205,11 +218,13 @@ Config.prototype.getConfig = function() {
 
   // set all endpoint paths to be local paths
   cfg.paths = extend({}, cfg.paths);
-  for (var e in this.endpoints)
-    cfg.paths[e + ':*'] = this.endpoints[e].local;
-
+  var endpoints = this.endpoints;
+  for (var e in endpoints) {
+    if (endpoints.hasOwnProperty(e))
+      cfg.paths[e + ':*'] = endpoints[e].local;
+  }
   return cfg;
-}
+};
 
 /*
  * EndpointPath object
@@ -222,21 +237,21 @@ function EndpointPath(name, endpointPath) {
   this.local = jspmPackages + '/' + name + '/*.js';
 
   this.mode = 'local';
-  if (endpointPath == this.remote)
+  if (endpointPath === this.remote)
     this.mode = 'remote';
   this.path = endpointPath;
 }
 EndpointPath.prototype.setLocal = function() {
   this.path = this.local;
   this.mode = 'local';
-}
+};
 EndpointPath.prototype.setRemote = function() {
   this.path = this.remote;
   this.mode = 'remote';
-}
+};
 EndpointPath.prototype.write = function() {
   return this.path;
-}
+};
 
 // convert structured configuration into a plain object
 // by calling the .write() methods of structured classes
@@ -247,14 +262,14 @@ function extractObj(obj, host) {
   for (var p in obj) {
     if (!obj.hasOwnProperty(p))
       continue;
-    if (p.substr(p.length - 1, 1) ==  '_')
+    if (p.substr(p.length - 1, 1) ===  '_')
       continue;
 
-    var val = obj[p], writeValue;
-    if (typeof val == 'string')
+    var val = obj[p];
+    if (typeof val === 'string')
       out[p] = val;
-    else if (typeof val == 'object') {
-      if (typeof val.write == 'function')
+    else if (typeof val === 'object') {
+      if (typeof val.write === 'function')
         out[p] = val.write();
       else if (val instanceof Array)
         out[p] = val;
@@ -262,24 +277,28 @@ function extractObj(obj, host) {
         out[p] = extractObj(val, {});
     }
   }
-  for (var p in host)
-    if (!(p in out))
-      out[p] = host[p];
+  for (var h in host)
+    if (host.hasOwnProperty(h) && !(h in out))
+      out[h] = host[h];
   return out;
 }
 
 Config.prototype.write = function() {
   // extract over original config to keep initial values
-  var cfg = extractObj(this, this.originalConfig_);
+  var cfg = extractObj(this, this.originalConfig_),
+      cfgEndpoints, cfgMap, cfgVersions;
 
   // allow * path to be overridden
   if (!cfg.paths['*'])
     cfg.paths['*'] = '*.js';
 
-  for (var e in cfg.endpoints) {
-    var val = cfg.endpoints[e];
-    delete cfg.endpoints[e];
-    cfg.endpoints[e + ':*'] = val;
+  cfgEndpoints = cfg.endpoints;
+  for (var e in cfgEndpoints) {
+    if (!cfgEndpoints.hasOwnProperty(e))
+      continue;
+    var val = cfgEndpoints[e];
+    delete cfgEndpoints[e];
+    cfgEndpoints[e + ':*'] = val;
   }
 
   extend(cfg.paths, alphabetize(cfg.endpoints));
@@ -290,22 +309,28 @@ Config.prototype.write = function() {
   delete cfg.baseMap;
   delete cfg.depMap;
 
-  for (var p in cfg.map) {
-    var subMap = cfg.map[p];
-    if (typeof subMap == 'object') {
+  cfgMap = cfg.map;
+  for (var p in cfgMap) {
+    if (!cfgMap.hasOwnProperty(p))
+      continue;
+    var subMap = cfgMap[p];
+    if (typeof subMap === 'object') {
       if (!hasProperties(subMap))
-        delete cfg.map[p];
+        delete cfgMap[p];
       else
-        cfg.map[p] = alphabetize(cfg.map[p]);
+        cfgMap[p] = alphabetize(cfgMap[p]);
     }
   }
 
-  for (var v in cfg.versions) {
-    var version = cfg.versions[v];
-    if (version.length == 1)
-      cfg.versions[v] = version[0];
-    if (version.length == 0)
-      delete cfg.versions[v];
+  cfgVersions = cfg.versions;
+  for (var v in cfgVersions) {
+    if (!cfgVersions.hasOwnProperty(v))
+      continue;
+    var version = cfgVersions[v];
+    if (version.length === 1)
+      cfgVersions[v] = version[0];
+    if (version.length === 0)
+      delete cfgVersions[v];
   }
 
   var configContent = '';
@@ -320,7 +345,7 @@ Config.prototype.write = function() {
   delete cfg.map;
   delete cfg.versions;
 
-  if (cfg.transpiler == 'traceur')
+  if (cfg.transpiler === 'traceur')
     delete cfg.transpiler;
 
   if (cfg.bundles && !hasProperties(cfg.bundles))
@@ -347,7 +372,7 @@ Config.prototype.write = function() {
     configContent += 'System.config(' + stringify({ versions: versions }) + ');' + config.newLine + config.newLine;
 
   return asp(fs.writeFile)(this.fileName_, configContent);
-}
+};
 module.exports = Config;
 
 

--- a/lib/config/package-name.js
+++ b/lib/config/package-name.js
@@ -28,7 +28,7 @@
 function Package(name) {
   this.exactName = name;
 
-  if (name.indexOf(':') != -1)
+  if (name.indexOf(':') !== -1)
     this.endpoint = name.split(':')[0];
 
   var packageParts = (this.endpoint ? name.substr(this.endpoint.length + 1) : name).split('/');
@@ -43,15 +43,17 @@ function Package(name) {
   this.name = (this.endpoint ? this.endpoint + ':' : '') + this.package;
   this.setVersion(version);
 }
+
 Package.prototype.setVersion = function(version) {
-  if (version == '*')
+  if (version === '*')
     version = '';
   this.version = version;
   var v = this.version ? '@' + this.version : '';
   this.exactPackage = this.package + v;
   this.exactName = this.name + v;
   return this;
-}
+};
+
 Package.prototype.setEndpoint = function(endpoint) {
   if (this.endpoint)
     throw 'Endpoint already set.';
@@ -59,16 +61,20 @@ Package.prototype.setEndpoint = function(endpoint) {
   this.exactName = endpoint + ':' + this.exactName;
   this.name = endpoint + ':' + this.name;
   return this;
-}
+};
+
 Package.prototype.copy = function() {
   return new Package(this.exactName);
-}
+};
+
 var path = require('path');
 var config = require('../config');
 Package.prototype.getPath = function() {
   return path.resolve(config.pjson.packages, this.endpoint, this.exactPackage);
-}
+};
+
 Package.prototype.write = function() {
   return this.exactName;
-}
+};
+
 module.exports = Package;

--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -15,7 +15,6 @@
  */
 
 var config = require('../config');
-var PackageName = require('./package-name');
 var path = require('path');
 var extend = require('../common').extend;
 var hasProperties = require('../common').hasProperties;
@@ -59,7 +58,7 @@ function PackageJSON(fileName) {
 
 PackageJSON.prototype.read = function(prompts) {
   if (this.read_)
-    throw "Package.json file already read";
+    throw 'Package.json file already read';
 
   this.read_ = true;
   var self = this;
@@ -68,11 +67,11 @@ PackageJSON.prototype.read = function(prompts) {
   return readJSON(this.fileName)
   .then(function(_pjson) {
     self.originalPjson = _pjson;
-    
+
     self.jspmPrefix = true;
     if (_pjson.registry && !_pjson.jspm)
       self.jspmPrefix = false;
-    
+
     // derive the jspm config from the 'jspm' property in the package.json
     // also sets the registry property if dependencies are jspm-prefixed
     pjson = config.derivePackageConfig(_pjson);
@@ -107,12 +106,12 @@ PackageJSON.prototype.read = function(prompts) {
     self.main = pjson.main || defaults.main;
 
     // NB can remove jspmPackages suport in time
-    self.packages = pjson.directories && pjson.directories.packages && path.resolve(self.dir, pjson.directories.packages)
-      || pjson.directories && pjson.directories.jspmPackages && path.resolve(self.dir, pjson.directories.jspmPackages) || defaults.packages;
+    self.packages = pjson.directories && pjson.directories.packages && path.resolve(self.dir, pjson.directories.packages) ||
+      pjson.directories && pjson.directories.jspmPackages && path.resolve(self.dir, pjson.directories.jspmPackages) || defaults.packages;
 
     defaults.configFile = path.resolve(self.baseURL, 'config.js');
     self.configFile = pjson.configFile && path.resolve(self.dir, pjson.configFile) || defaults.configFile;
-    
+
     self.format = pjson.format;
     self.map = extend({}, pjson.map || {});
 
@@ -120,10 +119,10 @@ PackageJSON.prototype.read = function(prompts) {
     self.useJSExtensions = pjson.useJSExtensions;
 
     self.buildConfig = extend({}, pjson.buildConfig || {});
-    
+
     return prompts;
   });
-}
+};
 
 PackageJSON.prototype.write = function() {
   var pjson = this.jspmPrefix ? {} : this.originalPjson;
@@ -132,27 +131,29 @@ PackageJSON.prototype.write = function() {
     delete pjson.jspm;
     pjson.registry = this.registry || globalConfig.config.registry;
   }
-  else if (this.registry != 'jspm') {
+  else if (this.registry !== 'jspm') {
     pjson.registry = this.registry;
   }
 
   var defaults = this.defaults;
 
   // only set properties that differ from the defaults
-  if (this.main != defaults.main)
+  if (this.main !== defaults.main)
     pjson.main = this.main;
 
   if (this.format)
     pjson.format = this.format;
 
   var directories = {};
-  if (this.baseURL != defaults.baseURL)
+  if (this.baseURL !== defaults.baseURL)
     directories.baseURL = this.baseURL;
-  if (this.packages != defaults.packages)
+  if (this.packages !== defaults.packages)
     directories.packages = this.packages;
 
   if (hasProperties(directories)) {
     for (var d in directories) {
+      if (!directories.hasOwnProperty(d))
+        continue;
       directories[d] = winPath(path.relative(this.dir, directories[d]));
       if (!directories[d])
         directories[d] = '.';
@@ -164,7 +165,7 @@ PackageJSON.prototype.write = function() {
   if (!hasProperties(pjson.directories))
     delete pjson.directories;
 
-  if (this.configFile != defaults.configFile)
+  if (this.configFile !== defaults.configFile)
     pjson.configFile = winPath(path.relative(this.dir, this.configFile));
 
   pjson.map = alphabetize(this.map);
@@ -172,21 +173,23 @@ PackageJSON.prototype.write = function() {
     delete pjson.map;
 
   pjson.dependencies = {};
-  var depValue;
-  for (var d in this.dependencies) {
-    var dep = this.dependencies[d];
+  var depValue, dependencies = this.dependencies;
+  for (var dkey in dependencies) {
+    if (!dependencies.hasOwnProperty(dkey))
+      continue;
+    var dep = dependencies[dkey];
     if (!dep)
       continue;
-    if (dep.endpoint == this.registry) {
-      if (d == dep.package)
+    if (dep.endpoint === this.registry) {
+      if (dkey === dep.package)
         depValue = dep.version;
       else
         depValue = dep.exactPackage;
     }
     else
       depValue = dep.exactName;
-    
-    pjson.dependencies[d] = depValue;
+
+    pjson.dependencies[dkey] = depValue;
   }
   pjson.dependencies = alphabetize(pjson.dependencies);
   if (!hasProperties(pjson.dependencies))
@@ -207,7 +210,7 @@ PackageJSON.prototype.write = function() {
 
   // NB check that the file hasn't changed since we opened it and if so, prompt
   return asp(fs.writeFile)(this.fileName, stringify(this.originalPjson) + config.newLine);
-}
+};
 
 // can take an existing non-jspm package.json
 function doInitPrompts(pjson, pjsonPath, prefixed) {
@@ -245,7 +248,7 @@ function doInitPrompts(pjson, pjsonPath, prefixed) {
     return ui.input('Enter config file path', pjson.configFile || base + 'config.js');
   })
   .then(function(configFile) {
-    pjson.configFile = path.relative(baseDir, path.resolve(configFile))
+    pjson.configFile = path.relative(baseDir, path.resolve(configFile));
     return prefixed;
   });
 }

--- a/lib/config/utils.js
+++ b/lib/config/utils.js
@@ -7,14 +7,14 @@ module.exports.extractObj = function extractObj(obj, host) {
   for (var p in obj) {
     if (!obj.hasOwnProperty(p))
       continue;
-    if (p.substr(0, 2) ==  '__')
+    if (p.substr(0, 2) ===  '__')
       continue;
 
     var val = obj[p];
-    if (typeof val == 'string')
+    if (typeof val === 'string')
       out[p] = val;
-    else if (typeof val == 'object') {
-      if (typeof val.write == 'function')
+    else if (typeof val === 'object') {
+      if (typeof val.write === 'function')
         out[p] = val.write();
       else if (val instanceof Array)
         out[p] = val;
@@ -22,8 +22,10 @@ module.exports.extractObj = function extractObj(obj, host) {
         out[p] = extractObj(val, {});
     }
   }
-  for (var p in host)
-    if (!(p in out))
-      out[p] = host[p];
+
+  for (var h in host)
+    if (host.hasOwnProperty(h) && !(h in out))
+      out[h] = host[h];
+
   return out;
 };

--- a/lib/core.js
+++ b/lib/core.js
@@ -22,17 +22,25 @@ var config = require('./config');
 var ep = require('./endpoint');
 var build = require('./build');
 var PackageName = require('./config/package-name');
-var request = require('request');
 var fs = require('graceful-fs');
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 var ncp = require('ncp');
-var link = require('./link');
 var asp = require('rsvp').denodeify;
 var System = require('systemjs');
 
 
 var core = module.exports;
+
+// var ghh = 'https://raw.githubusercontent.com/';
+
+// we always download the latest semver compatible version
+var lVersions = {
+  esml: '^0.14.0',
+  system: '^0.14.0',
+  traceur: '^0.0.84',
+  babel: '^4.1.1'
+};
 
 exports.run = function(moduleName) {
   return config.load()
@@ -47,7 +55,7 @@ exports.run = function(moduleName) {
   .catch(function(e) {
     ui.log('err', e.stack || e);
   });
-}
+};
 
 exports.build = function() {
   var saveConfig = false;
@@ -62,7 +70,7 @@ exports.build = function() {
   .then(function(doTranspile) {
     if (doTranspile)
       config.pjson.buildConfig.transpileES6 = true;
-    
+
     if (!config.pjson.buildConfig || config.pjson.buildConfig.minify === undefined) {
       saveConfig = true;
       return ui.confirm('Minify?', true);
@@ -98,7 +106,7 @@ exports.build = function() {
   }, function(err) {
     ui.log('err', err.stack || err);
   });
-}
+};
 
 exports.setMode = function(modes) {
   if (!(modes instanceof Array))
@@ -108,9 +116,9 @@ exports.setMode = function(modes) {
 
   return config.load()
   .then(function() {
-    if (modes.indexOf('local') == -1)
+    if (modes.indexOf('local') === -1)
       return true;
-    
+
     // set local
     Object.keys(config.loader.endpoints).forEach(function(e) {
       config.loader.endpoints[e].setLocal();
@@ -119,7 +127,7 @@ exports.setMode = function(modes) {
     msg += 'Loader set to local library sources\n';
   })
   .then(function(unmatched) {
-    if (modes.indexOf('remote') == -1)
+    if (modes.indexOf('remote') === -1)
       return unmatched;
 
     // set remote
@@ -138,7 +146,7 @@ exports.setMode = function(modes) {
       return msg;
     });
   });
-}
+};
 
 // checks if we need to download the loader files
 // if so, it does
@@ -156,7 +164,7 @@ exports.checkDlLoader = function() {
     throw err;
   })
   .then(function(cacheVersions) {
-    if (cacheVersions.toString() != [lVersions.esml, lVersions.system, transpilerName == 'babel' ? '' : lVersions.traceur, transpilerName == 'babel' ? lVersions['babel'] : ''].join(','))
+    if (cacheVersions.toString() !== [lVersions.esml, lVersions.system, transpilerName === 'babel' ? '' : lVersions.traceur, transpilerName === 'babel' ? lVersions.babel : ''].join(','))
       return exports.dlLoader(transpilerName);
 
     // even if version file is fresh, still check files exist
@@ -177,20 +185,11 @@ exports.checkDlLoader = function() {
         return exports.dlLoader(transpilerName);
     });
   });
-}
-
-var ghh = 'https://raw.githubusercontent.com/';
-
-// we always download the latest semver compatible version
-var lVersions = {
-  esml: '^0.14.0',
-  system: '^0.14.0',
-  traceur: '^0.0.84',
-  babel: '^4.1.1'
 };
 
 // mini endpoint API usage implementation
 var loaderFilesCacheDir = path.join(config.HOME, '.jspm', 'loader-files');
+
 function dl(name, repo, version) {
   var pkg = new PackageName(repo);
   var endpoint = ep.load(pkg.endpoint);
@@ -213,9 +212,9 @@ function dl(name, repo, version) {
 
     return asp(fs.readFile)(path.resolve(dlDir, '.hash'))
     .then(function(_hash) {
-      return _hash.toString() == vMatchLookup.hash;
+      return _hash.toString() === vMatchLookup.hash;
     }, function (e) {
-      if (e.code == 'ENOENT')
+      if (e.code === 'ENOENT')
         return;
       throw e;
     });
@@ -227,7 +226,7 @@ function dl(name, repo, version) {
     return endpoint.download(pkg.package, vMatch, vMatchLookup.hash, vMatchLookup.meta, dlDir)
     .then(function() {
       return fs.writeFile(path.resolve(dlDir, '.hash'), vMatchLookup.hash);
-    })
+    });
   })
   .then(function() {
     return vMatch;
@@ -244,7 +243,6 @@ function cp(file, name, transform) {
   });
 }
 
-
 exports.dlLoader = function(transpilerName, unminified, edge) {
   ui.log('info', 'Looking up loader files...');
   var min1 = unminified ? '.src' : '';
@@ -256,12 +254,12 @@ exports.dlLoader = function(transpilerName, unminified, edge) {
   return config.load()
   .then(function() {
     transpilerName = transpilerName || config.loader.transpiler;
-    babel = transpilerName == 'babel';
+    babel = transpilerName === 'babel';
     return asp(mkdirp)(config.pjson.packages);
   })
   .then(function() {
     // delete old versions
-    return asp(fs.readdir)(config.pjson.packages)
+    return asp(fs.readdir)(config.pjson.packages);
   })
   .then(function(files) {
     return Promise.all(files.filter(function(file) {
@@ -290,7 +288,7 @@ exports.dlLoader = function(transpilerName, unminified, edge) {
           unminified || cp('systemjs/dist/system.js.map', 'system.js.map')
         ]);
       }),
-      babel ? dl('babel', 'npm:babel-core', !edge ? lVersions['babel'] : 'latest').then(function(version) {
+      babel ? dl('babel', 'npm:babel-core', !edge ? lVersions.babel : 'latest').then(function(version) {
         using.babel = version;
         return Promise.all([
           cp('babel/browser.js', 'babel.js'),
@@ -300,19 +298,19 @@ exports.dlLoader = function(transpilerName, unminified, edge) {
       }) : dl('traceur', 'github:jmcriffey/bower-traceur', !edge ? lVersions.traceur : 'master').then(function(version) {
         using.traceur = version;
         return Promise.all([
-          cp('traceur/traceur' + min2 + '.js', 'traceur.js', 
+          cp('traceur/traceur' + min2 + '.js', 'traceur.js',
               function(s) { return s.replace('traceur.min.map', 'traceur.js.map'); }),
           unminified || cp('traceur/traceur.js', 'traceur.src.js'),
-          unminified || cp('traceur/traceur.min.map', 'traceur.js.map', 
+          unminified || cp('traceur/traceur.min.map', 'traceur.js.map',
               function(s) { return s.replace('"traceur.js"', '"traceur.src.js"').replace('"traceur.min.js"', '"traceur.js"'); })
         ]);
       }),
       babel ? Promise.resolve() : dl('traceur-runtime', 'github:jmcriffey/bower-traceur-runtime', !edge ? lVersions.traceur : 'master').then(function() {
         return Promise.all([
-          cp('traceur-runtime/traceur-runtime' + min2 + '.js', 'traceur-runtime.js', 
+          cp('traceur-runtime/traceur-runtime' + min2 + '.js', 'traceur-runtime.js',
               function(s) { return s.replace('traceur-runtime.min.map', 'traceur-runtime.js.map'); }),
           unminified || cp('traceur-runtime/traceur-runtime.js', 'traceur-runtime.src.js'),
-          unminified || cp('traceur-runtime/traceur-runtime.min.map', 'traceur-runtime.js.map', 
+          unminified || cp('traceur-runtime/traceur-runtime.min.map', 'traceur-runtime.js.map',
               function(s) { return s.replace('"traceur-runtime.js"', '"traceur-runtime.src.js"').replace('"traceur-runtime.min.js"', '"traceur-runtime.js"'); })
         ]);
       })
@@ -324,11 +322,11 @@ exports.dlLoader = function(transpilerName, unminified, edge) {
     ui.log('info', '  `systemjs@' + using.system + '`');
     ui.log('info', '  `' + transpilerName + '@' + using[transpilerName] + '`');
 
-    return asp(fs.writeFile)(path.resolve(config.pjson.packages, '.loaderversions'), 
-        [lVersions.esml, lVersions.system, transpilerName == 'babel' ? '' : lVersions.traceur, transpilerName == 'babel' ? lVersions['babel'] : ''].join(','));
+    return asp(fs.writeFile)(path.resolve(config.pjson.packages, '.loaderversions'),
+        [lVersions.esml, lVersions.system, transpilerName === 'babel' ? '' : lVersions.traceur, transpilerName === 'babel' ? lVersions.babel : ''].join(','));
   })
   .then(function() {
-    if (config.loader.transpiler != transpilerName) {
+    if (config.loader.transpiler !== transpilerName) {
       config.loader.transpiler = transpilerName;
       return config.save()
       .then(function() {
@@ -341,13 +339,13 @@ exports.dlLoader = function(transpilerName, unminified, edge) {
   }, function(err) {
     ui.log('err', 'Error downloading loader files \n' + (err.stack || err));
   });
-}
+};
 
 exports.init = function init(basePath, ask) {
   if (basePath)
     process.env.jspmConfigPath = path.resolve(basePath, 'package.json');
   var relBase = path.relative(process.cwd(), path.dirname(process.env.jspmConfigPath));
-  if (relBase != '')
+  if (relBase !== '')
     ui.log('info', 'Initializing package at `' + relBase + '/`\nUse %jspm init .% to intialize into the current folder.');
   return config.load(ask)
   .then(function() {
@@ -362,4 +360,4 @@ exports.init = function init(basePath, ask) {
   .catch(function(err) {
     ui.log('err', err.stack || err);
   });
-}
+};

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -21,16 +21,6 @@ var ui = require('./ui');
 var dextend = require('./common').dextend;
 var hasProperties = require('./common').hasProperties;
 
-process.on('exit', function() {
-  // dispose all loaded endpoints
-  // allows for saving cache state using sync fs
-  for (var e in endpointClasses) {
-    if (endpointClasses[e].dispose)
-      endpointClasses[e].dispose();
-  }
-});
-
-var ep = exports;
 
 /*
   Endpoint API
@@ -44,11 +34,20 @@ var endpointClasses = {
   }
 };
 
+process.on('exit', function() {
+  // dispose all loaded endpoints
+  // allows for saving cache state using sync fs
+  for (var e in endpointClasses) {
+    if (endpointClasses[e].dispose)
+      endpointClasses[e].dispose();
+  }
+});
+
 var endpointHooks = ['locate', 'lookup', 'download', 'getPackageConfig', 'processPackageConfig', 'build', 'getOverride'];
 
 exports.load = function(endpoint) {
   // add local as an endpoint if not existing, this way only created when used
-  if (endpoint == 'local' && !globalConfig.config.endpoints.local) {
+  if (endpoint === 'local' && !globalConfig.config.endpoints.local) {
     globalConfig.config.endpoints.local = {};
     globalConfig.save();
   }
@@ -76,24 +75,24 @@ exports.load = function(endpoint) {
     if (!options.handler)
       throw 'Endpoint %' + endpoint + '% not found.';
 
-    var endpointClass = require(options.handler);
+    var EndpointClass = require(options.handler);
     var endpointPackageJSON = require(options.handler + '/package.json');
     var versionString = endpointPackageJSON.name + '@' + endpointPackageJSON.version.split('.').splice(0, 2).join('.');
     options.versionString = versionString;
 
-    var endpointInstance = endpointClasses[endpoint] = new endpointClass(options, ui);
-    endpointInstance.constructor = endpointClass;
-    
+    var endpointInstance = endpointClasses[endpoint] = new EndpointClass(options, ui);
+    endpointInstance.constructor = EndpointClass;
+
     var timeoutLookups = options.timeouts.lookups * 1000;
     var timeoutDownload = options.timeouts.download * 1000;
     var timeoutBuild = options.timeouts.build * 1000;
 
     // allow options to have been mutated by constructor
-    if (options.timeouts.lookups == 30)
+    if (options.timeouts.lookups === 30)
       delete options.timeouts.lookups;
-    if (options.timeouts.download == 300)
+    if (options.timeouts.download === 300)
       delete options.timeouts.download;
-    if (options.timeouts.build == 300)
+    if (options.timeouts.build === 300)
       delete options.timeouts.build;
     if (!hasProperties(options.timeouts))
       delete options.timeouts;
@@ -119,9 +118,9 @@ exports.load = function(endpoint) {
         var args = arguments;
         var retries = 0;
         var timeout;
-        if (hook == 'download')
+        if (hook === 'download')
           timeout = timeoutDownload;
-        else if (hook == 'build')
+        else if (hook === 'build')
           timeout = timeoutBuild;
         else
           timeout = timeoutLookups;
@@ -155,13 +154,13 @@ exports.load = function(endpoint) {
 
           function checkRetry(err) {
             // don't retry build or processPackageConfig
-            if (hook == 'build' || hook == 'processPackageConfig')
+            if (hook === 'build' || hook === 'processPackageConfig')
               retries = maxRetries;
             retries++;
-            ui.log('warn', (err ? 'Error' : 'Timed out') + ' on ' + hook
-               + (typeof args[0] == 'string' ? ' for `' + endpoint + ':' + args[0] + '`' : '') 
-               + (retries <= maxRetries ? ', retrying (' + retries + ').' : '')
-               + (err ? '\n' + (err.stack || err) : ''));
+            ui.log('warn', (err ? 'Error' : 'Timed out') + ' on ' + hook +
+               (typeof args[0] === 'string' ? ' for `' + endpoint + ':' + args[0] + '`' : '') +
+               (retries <= maxRetries ? ', retrying (' + retries + ').' : '') +
+               (err ? '\n' + (err.stack || err) : ''));
             if (retries <= maxRetries)
               return tryHook();
             else
@@ -170,7 +169,7 @@ exports.load = function(endpoint) {
 
           tryHook();
         });
-      }
+      };
     });
 
     return endpointInstance;
@@ -179,10 +178,11 @@ exports.load = function(endpoint) {
     ui.log('err', e.stack || e);
     throw 'Unable to load endpoint %' + endpoint + '%';
   }
-}
+};
 
 exports.configure = function(endpoint) {
-  var endpointConfig = globalConfig.config.endpoints[endpoint] || {};
+  var endpointConfig = globalConfig.config.endpoints[endpoint] || {},
+      EndpointClass;
 
   if (!endpointConfig.handler)
     throw 'Endpoint %' + endpoint + '% not found.';
@@ -191,14 +191,14 @@ exports.configure = function(endpoint) {
   delete endpointConfig.handler;
 
   try {
-    var endpointClass = require(handler);
+    EndpointClass = require(handler);
   }
   catch(e) {
     throw 'Endpoint handler`' + handler + '` not installed.';
   }
 
   endpointConfig.name = endpoint;
-  return Promise.resolve(endpointClass.configure && endpointClass.configure(endpointConfig, ui) || endpointConfig)
+  return Promise.resolve(EndpointClass.configure && EndpointClass.configure(endpointConfig, ui) || endpointConfig)
   .then(function(_config) {
     delete _config.name;
     _config.handler = handler;
@@ -207,7 +207,7 @@ exports.configure = function(endpoint) {
   .then(function() {
     globalConfig.save();
   });
-}
+};
 
 // jspm endpoint create mycompany jspm-github
 // creates a custom endpoint based on the given handler
@@ -215,7 +215,7 @@ exports.create = function(name, handler, override) {
 
   // handle override prompts etc
   if (!override && globalConfig.config.endpoints[name]) {
-    if (globalConfig.config.endpoints[name].handler == handler)
+    if (globalConfig.config.endpoints[name].handler === handler)
       return ui.confirm('Endpoint %' + name + '% already exists. Do you want to reconfigure it now?')
       .then(function(configure) {
         if (configure)
@@ -241,4 +241,4 @@ exports.create = function(name, handler, override) {
 
   // load the endpoint and configure it
   return exports.configure(name);
-}
+};

--- a/lib/global-config.js
+++ b/lib/global-config.js
@@ -28,7 +28,7 @@ function save() {
     fs.mkdirSync(HOME + path.sep + '.jspm');
   }
   catch(e) {
-    if (e.code != 'EEXIST')
+    if (e.code !== 'EEXIST')
       throw 'Unable to create jspm system folder\n' + e.stack;
   }
   try {
@@ -89,8 +89,8 @@ exports.set = function(name, val) {
   var config = exports.config;
   var part;
   while (nameParts.length > 1) {
-    var part = nameParts.shift();
-    config[part] = typeof config[part] == 'object' ? config[part] : {};
+    part = nameParts.shift();
+    config[part] = typeof config[part] === 'object' ? config[part] : {};
     config = config[part];
   }
   if (val) {
@@ -100,6 +100,6 @@ exports.set = function(name, val) {
     // If no value is specified, then remove property from config
     delete config[nameParts[0]];
   }
-  
+
   save();
-}
+};

--- a/lib/install.js
+++ b/lib/install.js
@@ -274,7 +274,7 @@ function install(name, target, options, seen) {
 
       if (options.inject)
         return pkg.inject(resolution, downloadDeps);
-        
+
       return pkg.download(resolution, options.override, options.unlink, downloadDeps);
     })
     .then(function(fresh) {
@@ -637,7 +637,7 @@ function loadExistingRange(name, parent, inject) {
 
         // if the package is installed but not in jspm_packages
         // then we wait on the getPackageConfig or download of the package here
-        secondaryDepsPromises[parent] = new Promise(function(resolve, reject) {
+        return (secondaryDepsPromises[parent] = new Promise(function(resolve, reject) {
           if (inject)
             return pkg.inject(parentPkg, resolve).catch(reject);
 
@@ -655,8 +655,7 @@ function loadExistingRange(name, parent, inject) {
           .then(function(pjson) {
             return pkg.processDeps(pjson.dependencies || {}, pjson.registry);
           });
-        });
-        return secondaryDepsPromises[parent];
+        }));
       });
     })
     .then(function(deps) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -36,19 +36,20 @@ var fs = require('graceful-fs');
 var primaryRanges = {};
 var secondaryRanges = {};
 
+var installedResolves = {};
+var installingResolves = {};
+
 var installed;
 var installing = {
   baseMap: {},
   depMap: {}
 };
 
-var downloads = {};
-
 // NB remove assertions for release
-function assert(statement, name) {
-  if (!statement)
-    throw new TypeError('Assertion Failed: ' + name);
-}
+// function assert(statement, name) {
+//  if (!statement)
+//    throw new TypeError('Assertion Failed: ' + name);
+// }
 
 /*
  * Main install API wrapper
@@ -69,11 +70,11 @@ function assert(statement, name) {
  *
  */
 exports.install = function(targets, options) {
-  if (typeof targets == 'string') {
+  if (typeof targets === 'string') {
     var name = targets;
     targets = {};
-    targets[name] = typeof options == 'string' ? options : '';
-    options = typeof options == 'object' ? options : arguments[2];
+    targets[name] = typeof options === 'string' ? options : '';
+    options = typeof options === 'object' ? options : arguments[2];
   }
   options = options || {};
 
@@ -101,11 +102,9 @@ exports.install = function(targets, options) {
     .then(function() {
       // after every install, show forks
       showVersions(true);
-    })
+    });
   });
-}
-
-
+};
 
 /*
  * install('jquery', 'jquery', { latest, lock, parent, inject, link, unlink, override } [, seen])
@@ -211,7 +210,7 @@ function install(name, target, options, seen) {
           // alter this secondary install to the other primary or secondary
           if (!consolidated && options.parent && semver.match(target.version, forkVersion)) {
             consolidated = true;
-            if (forkVersion != resolution.version) {
+            if (forkVersion !== resolution.version) {
               var newResolution = resolution.copy().setVersion(forkVersion);
               logResolution(installingResolves, resolution, newResolution);
               resolution = newResolution;
@@ -222,7 +221,7 @@ function install(name, target, options, seen) {
       // c. Forks against the existing tree are handled by upgrading the existing tree,
       //    at both primary and secondary levels, with the secondary fork potentially rolling back as well.
       resolveForks(installed, name, options.parent, resolution, function(forkVersion, forkRanges) {
-        if (options.latest && semver.compare(forkVersion, resolution.version) == 1)
+        if (options.latest && semver.compare(forkVersion, resolution.version) === 1)
           return;
 
         if (forkRanges.every(function(forkRange) {
@@ -237,11 +236,11 @@ function install(name, target, options, seen) {
           var bestSecondaryRollback = resolution;
           forkRanges.forEach(function(forkRange) {
             var forkLatest = getLatestMatch(forkRange);
-            if (semver.compare(bestSecondaryRollback.version, forkLatest.version) == 1)
+            if (semver.compare(bestSecondaryRollback.version, forkLatest.version) === 1)
               bestSecondaryRollback = forkLatest;
           });
 
-          if (semver.compare(bestSecondaryRollback.version, forkVersion) == -1)
+          if (semver.compare(bestSecondaryRollback.version, forkVersion) === -1)
             bestSecondaryRollback = getLatestMatch(forkVersion);
 
           if (semver.match(target.version, bestSecondaryRollback.version)) {
@@ -262,7 +261,7 @@ function install(name, target, options, seen) {
     // -- handle circular installs --
 
     seen = seen || [];
-    if (seen.indexOf(resolution.exactName) != -1)
+    if (seen.indexOf(resolution.exactName) !== -1)
       return;
     seen.push(resolution.exactName);
 
@@ -286,7 +285,7 @@ function install(name, target, options, seen) {
 
       return dependencyDownloads;
     })
-    .then(function(depMap) {
+    .then(function() {
       if (!options.parent)
         logInstall(name, target, resolution, options);
     });
@@ -307,7 +306,7 @@ function install(name, target, options, seen) {
 
     // update the dependency range tree
     if (!options.parent) {
-      if (!primaryRanges[name] || primaryRanges[name].exactName != target.exactName)
+      if (!primaryRanges[name] || primaryRanges[name].exactName !== target.exactName)
         primaryRanges[name] = target.copy();
       // store in package.json
       if (!options.link)
@@ -319,7 +318,7 @@ function install(name, target, options, seen) {
       if (!secondaryRanges[options.parent][name])
         secondaryRanges[options.parent][name] = target.copy();
       else
-        if (secondaryRanges[options.parent][name] && secondaryRanges[options.parent][name].exactName != target.exactName)
+        if (secondaryRanges[options.parent][name] && secondaryRanges[options.parent][name].exactName !== target.exactName)
           ui.log('warn', 'Currently installed dependency ranges of `' + options.parent + '` are not consistent ( %' + secondaryRanges[options.parent][name].exactName + '% should be %' + target.exactName + '%)');
     }
   }
@@ -355,10 +354,10 @@ function getInstalledMatch(target, parent, name) {
   // otherwise seek an installed match
   var match;
   function checkMatch(pkg) {
-    if (pkg.name != target.name)
+    if (pkg.name !== target.name)
       return;
     if (semver.match(target.version, pkg.version)) {
-      if (!match || match && semver.compare(pkg.version, match.version) == 1)
+      if (!match || match && semver.compare(pkg.version, match.version) === 1)
         match = pkg.copy();
     }
   }
@@ -460,35 +459,32 @@ function logInstall(name, target, resolution, options) {
   else
     ui.log('ok', verb + ' %' + name + '% as `' + target.exactName + '` (' + resolution.version + ')');
 }
+
 function getUpdateRangeText(existing, update) {
-  if (existing.name == update.name)
+  if (existing.name === update.name)
     return '`' + existing.version + '` -> `' + update.version + '`';
   else
     return '`' + existing.exactName + '` -> `' + update.exactName + '`';
 }
 
-
-var installedResolves = {};
-var installingResolves = {};
-
 // go through the baseMap and depMap, changing FROM to TO
 // keep a log of what we did in resolveLog
 function doResolution(tree, from, to) {
-  if (from.exactName == to.exactName)
+  if (from.exactName === to.exactName)
     return;
 
   // add this to the resolve log, including deep-updating resolution chains
-  logResolution(tree == installed ? installedResolves : installingResolves, from, to);
+  logResolution(tree === installed ? installedResolves : installingResolves, from, to);
 
   Object.keys(tree.baseMap).forEach(function(dep) {
-    if (tree.baseMap[dep].exactName == from.exactName)
+    if (tree.baseMap[dep].exactName === from.exactName)
       tree.baseMap[dep] = to.copy();
   });
 
   Object.keys(tree.depMap).forEach(function(parent) {
     var curMap = tree.depMap[parent];
     Object.keys(curMap).forEach(function(dep) {
-      if (curMap[dep].exactName == from.exactName)
+      if (curMap[dep].exactName === from.exactName)
         curMap[dep] = to.copy();
     });
   });
@@ -498,7 +494,7 @@ function logResolution(resolveLog, from, to) {
   resolveLog[from.exactName] = to.exactName;
 
   Object.keys(resolveLog).forEach(function(resolveFrom) {
-    if (resolveLog[resolveFrom] == from.exactName)
+    if (resolveLog[resolveFrom] === from.exactName)
       resolveLog[resolveFrom] = to.exactName;
   });
 }
@@ -508,11 +504,11 @@ function logResolution(resolveLog, from, to) {
 function loadExistingForkRanges(resolution, name, parentName, inject) {
   var tree = installed;
   return Promise.all(Object.keys(tree.baseMap).map(function(dep) {
-    if (!parentName && dep == name)
+    if (!parentName && dep === name)
       return;
 
     var primary = tree.baseMap[dep];
-    if (primary.name != resolution.name)
+    if (primary.name !== resolution.name)
       return;
 
     return loadExistingRange(dep, null, inject);
@@ -522,12 +518,12 @@ function loadExistingForkRanges(resolution, name, parentName, inject) {
       var curDepMap = tree.depMap[parent];
 
       return Promise.all(Object.keys(curDepMap).map(function(dep) {
-        if (parent == parentName && dep == name)
+        if (parent === parentName && dep === name)
           return;
 
         var secondary = curDepMap[dep];
 
-        if (secondary.name != resolution.name)
+        if (secondary.name !== resolution.name)
           return;
 
         return loadExistingRange(dep, parent, inject);
@@ -541,7 +537,7 @@ function visitForkRanges(tree, resolution, name, parentName, visit) {
   // go through and run resolutions against the fork list
   Object.keys(tree.baseMap).forEach(function(dep) {
     var primary = tree.baseMap[dep];
-    if (primary.name != resolution.name)
+    if (primary.name !== resolution.name)
       return;
 
     visit(dep, null, primary, primaryRanges[dep]);
@@ -553,11 +549,11 @@ function visitForkRanges(tree, resolution, name, parentName, visit) {
     Object.keys(curDepMap).forEach(function(dep) {
       var secondary = curDepMap[dep];
 
-      if (secondary.name != resolution.name)
+      if (secondary.name !== resolution.name)
         return;
 
       // its not a fork of itself
-      if (dep == name && parent == parentName)
+      if (dep === name && parent === parentName)
         return;
 
       // skip if we don't have a range
@@ -585,7 +581,7 @@ function resolveForks(tree, name, parentName, resolution, resolve) {
 
     // we only work with stuff within it's own matching range
     // not user overrides
-    if (range.name != resolved.name || !semver.match(range.version, resolved.version))
+    if (range.name !== resolved.name || !semver.match(range.version, resolved.version))
       return;
 
     var forkObj = forks[resolved.version];
@@ -605,7 +601,7 @@ function resolveForks(tree, name, parentName, resolution, resolve) {
     var forkObj = forks[forkVersion];
 
     var newVersion = resolve(forkVersion, forkObj.ranges, forkObj.allSecondary);
-    if (!newVersion || newVersion == forkVersion)
+    if (!newVersion || newVersion === forkVersion)
       return;
 
     var from = resolution.copy().setVersion(forkVersion);
@@ -641,7 +637,7 @@ function loadExistingRange(name, parent, inject) {
 
         // if the package is installed but not in jspm_packages
         // then we wait on the getPackageConfig or download of the package here
-        return secondaryDepsPromises[parent] = new Promise(function(resolve, reject) {
+        secondaryDepsPromises[parent] = new Promise(function(resolve, reject) {
           if (inject)
             return pkg.inject(parentPkg, resolve).catch(reject);
 
@@ -660,6 +656,7 @@ function loadExistingRange(name, parent, inject) {
             return pkg.processDeps(pjson.dependencies || {}, pjson.registry);
           });
         });
+        return secondaryDepsPromises[parent];
       });
     })
     .then(function(deps) {
@@ -699,16 +696,16 @@ function showInstallGraph(pkg) {
     ui.log('info', '\nInstalled versions of %' + pkg.name + '%');
     visitForkRanges(installed, pkg, null, null, function(name, parent, resolved, range) {
       found = true;
-      if (range.version == '')
+      if (range.version === '')
         range.version = '*';
-      var rangeVersion = range.name == resolved.name ? range.version : range.exactName;
-      if (range.version == '*')
+      var rangeVersion = range.name === resolved.name ? range.version : range.exactName;
+      if (range.version === '*')
         range.version = '';
 
       if (!parent)
         ui.log('info', '\n       %' + name + '% `' + resolved.version + '` (' + rangeVersion + ')');
       else {
-        if (lastParent != parent) {
+        if (lastParent !== parent) {
           ui.log('info', '\n  ' + parent);
           lastParent = parent;
         }
@@ -738,7 +735,7 @@ function showVersions(forks) {
         linkedVersions[dep.exactName] = true;
     }
     catch(e) {}
-    if (vList.indexOf(version) == -1)
+    if (vList.indexOf(version) === -1)
       vList.push(version);
   }
 
@@ -770,9 +767,9 @@ function showVersions(forks) {
       }
       else
         return '`' + version + '`';
-    })
+    });
 
-    if (forks && vList.length == 1)
+    if (forks && vList.length === 1)
       return;
 
     if (!shownIntro) {
@@ -823,17 +820,17 @@ function clean() {
 
     // now that we have the package list, remove everything not in it
     Object.keys(config.loader.depMap).forEach(function(dep) {
-      if (packageList.indexOf(dep) == -1) {
+      if (packageList.indexOf(dep) === -1) {
         ui.log('info', 'Clearing configuration for `' + dep + '`');
         delete config.loader.depMap[dep];
       }
     });
 
     return readDirWithDepth(config.pjson.packages, function(dirname) {
-      if (dirname.indexOf('@') == -1)
+      if (dirname.indexOf('@') === -1)
         return true;
       // causes mains to be ignored
-      if (dirname.substr(dirname.length - 3, 3) == '.js')
+      if (dirname.substr(dirname.length - 3, 3) === '.js')
         return true;
     });
   })
@@ -842,7 +839,7 @@ function clean() {
     packageDirs
     .filter(function(dir) {
       var exactName = path.relative(config.pjson.packages, dir).replace(path.sep, ':').replace(/\\/g, '/'); // (win)
-      var remove = packageList.indexOf(exactName) == -1;
+      var remove = packageList.indexOf(exactName) === -1;
       if (remove)
         ui.log('info', 'Removing package files for `' + exactName + '`');
       return remove;
@@ -852,11 +849,11 @@ function clean() {
       .then(function() {
         // remove the main as well
         return asp(fs.unlink)(dir + '.js').catch(function(e) {
-          if (e.code == 'ENOENT')
+          if (e.code === 'ENOENT')
             return;
           throw e;
         });
-      })
+      });
     }));
   })
   .then(function() {
@@ -870,7 +867,7 @@ function readDirWithDepth(dir, depthCheck) {
   var flatDirs = [];
   return asp(fs.readdir)(dir)
   .catch(function(e) {
-    if (e.code == 'ENOTDIR')
+    if (e.code === 'ENOTDIR')
       return;
     throw e;
   })
@@ -905,7 +902,7 @@ function getDependentPackages(pkg, packages) {
     return;
   Object.keys(depMap).forEach(function(dep) {
     var curPkg = depMap[dep].exactName;
-    if (packages.indexOf(curPkg) != -1)
+    if (packages.indexOf(curPkg) !== -1)
       return;
     getDependentPackages(curPkg, packages);
   });
@@ -924,7 +921,7 @@ exports.uninstall = function(names) {
     names.forEach(function(name) {
       if (!config.pjson.dependencies[name]) {
         ui.log('warn', 'Dependency %' + name + '% is not an existing primary install.');
-        return
+        return;
       }
 
       delete config.pjson.dependencies[name];
@@ -933,7 +930,7 @@ exports.uninstall = function(names) {
 
     return clean();
   });
-}
+};
 
 /*
  * Resolve all installs of the given package to a specific version
@@ -952,7 +949,7 @@ exports.resolveOnly = function(pkg) {
   .then(function() {
     Object.keys(config.loader.baseMap).forEach(function(name) {
       var curPkg = config.loader.baseMap[name];
-      if (curPkg.endpoint == pkg.endpoint && curPkg.package == pkg.package && curPkg.version != pkg.version) {
+      if (curPkg.endpoint === pkg.endpoint && curPkg.package === pkg.package && curPkg.version !== pkg.version) {
         didSomething = true;
         ui.log('info', 'Primary install ' + getUpdateRangeText(curPkg, pkg));
         config.loader.baseMap[name] = pkg.copy();
@@ -963,7 +960,7 @@ exports.resolveOnly = function(pkg) {
       var curMap = config.loader.depMap[parent];
       Object.keys(curMap).forEach(function(name) {
         var curPkg = curMap[name];
-        if (curPkg.endpoint == pkg.endpoint && curPkg.package == pkg.package && curPkg.version != pkg.version) {
+        if (curPkg.endpoint === pkg.endpoint && curPkg.package === pkg.package && curPkg.version !== pkg.version) {
           didSomething = true;
           ui.log('info', 'In %' + parent + '% ' + getUpdateRangeText(curPkg, pkg));
           curMap[name] = pkg.copy();
@@ -978,9 +975,5 @@ exports.resolveOnly = function(pkg) {
       ui.log('ok', 'Resolution to only use `' + pkg.exactName + '` completed successfully.');
     else
       ui.log('ok', '`' + pkg.exactName + '` is already the only version of the package in use.');
-  })
-}
-
-
-
-
+  });
+};

--- a/lib/link.js
+++ b/lib/link.js
@@ -30,12 +30,12 @@ exports.link = function(name, dir, force) {
   var pjson, linkDir, pkg;
 
   return Promise.resolve()
-  .then(function(_pjson) {
+  .then(function() {
     try {
       pkg = new PackageName(name);
     }
     catch(e) {
-      throw 'Invalid package name to link into'
+      throw 'Invalid package name to link into';
     }
 
     // set the endpoint, name or version from the package.json if necessary
@@ -103,7 +103,7 @@ exports.link = function(name, dir, force) {
   }, function(err) {
     ui.log('err', err.stack || err);
   });
-}
+};
 
 exports.lookup = function(pkg) {
   var packageParts = pkg.package.split('/');
@@ -116,7 +116,7 @@ exports.lookup = function(pkg) {
     var hasVersions;
     files
     .filter(function(file) {
-      return file.substr(0, file.lastIndexOf('@')) == packagePart;
+      return file.substr(0, file.lastIndexOf('@')) === packagePart;
     })
     .forEach(function(file) {
       hasVersions = true;
@@ -132,13 +132,13 @@ exports.lookup = function(pkg) {
         return;
 
       return pkg.copy().setVersion(lookupObj.version);
-    }
+    };
   }, function(err) {
-    if (err.code == 'ENOENT')
+    if (err.code === 'ENOENT')
       throw 'No linked versions found for `' + pkg.name + '`';
     throw err;
   });
-}
+};
 
 exports.symlink = function(pkg, downloadDeps) {
   var linkDir = path.resolve(config.HOME, '.jspm', 'linked', pkg.endpoint, pkg.exactPackage);
@@ -149,7 +149,7 @@ exports.symlink = function(pkg, downloadDeps) {
 
   return asp(fs.readlink)(dir)
   .then(function(linkString) {
-    if (linkString == linkDir) {
+    if (linkString === linkDir) {
       fresh = true;
       return;
     }
@@ -164,7 +164,7 @@ exports.symlink = function(pkg, downloadDeps) {
   }, function(err) {
     if (err.code === 'ENOENT')
       return;
-    if (err.code !== 'EINVAL' && err.code != 'UNKNOWN')
+    if (err.code !== 'EINVAL' && err.code !== 'UNKNOWN')
       throw err;
 
     return Promise.resolve(ui.confirm('`' + pkg.exactName + '` already installed, are you sure you want to link over it?', true))
@@ -191,11 +191,10 @@ exports.symlink = function(pkg, downloadDeps) {
     .then(function(_pjson) {
       pjson = config.derivePackageConfig(_pjson);
       return package.createMain(pkg, pjson, dir);
-    })
+    });
   })
   .then(function() {
     downloadDeps(package.processDeps(pjson.dependencies, pjson.registry));
     return fresh;
   });
-}
-
+};

--- a/lib/package.js
+++ b/lib/package.js
@@ -73,14 +73,13 @@ exports.locate = function(target) {
     if (locateCache[target.endpoint][target.package])
       return locateCache[target.endpoint][target.package];
 
-    locateCache[target.endpoint][target.package] = Promise.resolve(endpoint.locate(target.package))
+    return (locateCache[target.endpoint][target.package] = Promise.resolve(endpoint.locate(target.package))
     .then(function(located) {
       // NB support versioned registry
       if (target.endpoint === globalConfig.config.registry)
         registryCache[target.package] = located.redirect;
       return located;
-    });
-    return locateCache[target.endpoint][target.package];
+    }));
   })
   .then(function(located) {
     if (!located)

--- a/lib/package.js
+++ b/lib/package.js
@@ -39,9 +39,9 @@ var jspmVersion = require('../package.json').version.split('.').splice(0, 2).joi
 var registryCache = exports.registryCache = {};
 
 function md5(input) {
-  var md5 = crypto.createHash('md5');
-  md5.update(input);
-  return md5.digest('hex');
+  var md5Hash = crypto.createHash('md5');
+  md5Hash.update(input);
+  return md5Hash.digest('hex');
 }
 
 var _pkg = module.exports;
@@ -73,13 +73,14 @@ exports.locate = function(target) {
     if (locateCache[target.endpoint][target.package])
       return locateCache[target.endpoint][target.package];
 
-    return locateCache[target.endpoint][target.package] = Promise.resolve(endpoint.locate(target.package))
+    locateCache[target.endpoint][target.package] = Promise.resolve(endpoint.locate(target.package))
     .then(function(located) {
       // NB support versioned registry
-      if (target.endpoint == globalConfig.config.registry)
+      if (target.endpoint === globalConfig.config.registry)
         registryCache[target.package] = located.redirect;
       return located;
     });
+    return locateCache[target.endpoint][target.package];
   })
   .then(function(located) {
     if (!located)
@@ -95,13 +96,13 @@ exports.locate = function(target) {
       throw 'Repo `' + target.name + '` not found!';
 
     throw 'Invalid endpoint locate response for %' + target.endpoint + '%';
-  }, function(e) {
+  }, function() {
     throw 'Error locating `' + target.name + '`.';
   });
-}
+};
 
 var lookupPromises = {};
-var lookups = {}
+var lookups = {};
 
 exports.lookup = function(pkg) {
   return Promise.resolve()
@@ -113,7 +114,8 @@ exports.lookup = function(pkg) {
 
     ui.log('info', 'Looking up `' + pkg.name + '`');
 
-    return lookupPromises[pkg.package] = Promise.resolve(ep.load(pkg.endpoint).lookup(pkg.package));
+    lookupPromises[pkg.package] = Promise.resolve(ep.load(pkg.endpoint).lookup(pkg.package));
+    return lookupPromises[pkg.package];
   })
   .then(function(lookup) {
     if (lookup.notfound)
@@ -130,11 +132,11 @@ exports.lookup = function(pkg) {
         return;
 
       return pkg.copy().setVersion(lookupObj.version);
-    }
-  }, function(e) {
+    };
+  }, function() {
     throw 'Error looking up `' + pkg.name + '`.';
   });
-}
+};
 
 exports.getVersionMatch = getVersionMatch;
 function getVersionMatch(pkgVersion, versions) {
@@ -146,7 +148,7 @@ function getVersionMatch(pkgVersion, versions) {
     if (versions[v].stable === false || versions[v].exactOnly)
       exactVersions.push(v);
     else
-      versionList.push(v);    
+      versionList.push(v);
   });
 
   exactVersions.sort(semver.compare).reverse();
@@ -157,7 +159,7 @@ function getVersionMatch(pkgVersion, versions) {
     var version = versionList[i];
 
     var semverMatch = version.match(semver.semverRegEx);
-    
+
     // ignore unstable
     // (stable is semver, without prerelease)
     if (!semverMatch || !semverMatch[1] || !semverMatch[2] || !semverMatch[3] || semverMatch[4])
@@ -168,20 +170,20 @@ function getVersionMatch(pkgVersion, versions) {
   }
 
   // if we asked for latest, and nothing stable found, use master or otherwise top
-  if (!pkgVersion) {    
+  if (!pkgVersion) {
     if (versions.master)
-      return versions['master'];
+      return versions.master;
     return versions[versionList[0] || exactVersions[0]];
   }
-  
+
   // next try an unstable version range match in tags then branches
-  for (var i = 0; i < versionList.length; i++) {
-    if (semver.match(pkgVersion, versionList[i]))
-      return versions[versionList[i]];
+  for (var j = 0; j < versionList.length; j++) {
+    if (semver.match(pkgVersion, versionList[j]))
+      return versions[versionList[j]];
   }
-  for (var i = 0; i < exactVersions.length; i++) {
-    if (semver.match(pkgVersion, exactVersions[i]))
-      return versions[exactVersions[i]];
+  for (var k = 0; k < exactVersions.length; k++) {
+    if (semver.match(pkgVersion, exactVersions[k]))
+      return versions[exactVersions[k]];
   }
 
   // finally check for an exact tag match
@@ -196,7 +198,7 @@ function getDirInfo(dir) {
     // check if the folder already exists
     return asp(fs.stat)(dir)
     .catch(function(err) {
-      if (err.code == 'ENOENT')
+      if (err.code === 'ENOENT')
         return;
       throw err;
     });
@@ -216,7 +218,7 @@ function getDirInfo(dir) {
 
       // otherwise do the hash check
       return asp(fs.readFile)(path.resolve(dir, '.jspm-hash'))
-      .then(function(_hash) { 
+      .then(function(_hash) {
         return { hash: _hash.toString() };
       }, function(err) {
         if (err.code === 'ENOENT')
@@ -250,8 +252,10 @@ function processDeps(deps, registry) {
   Object.keys(deps).forEach(function(p) {
     var dep = deps[p];
 
-    if (dep instanceof PackageName)
-      return outdeps[p] = dep;
+    if (dep instanceof PackageName) {
+      outdeps[p] = dep;
+      return outdeps[p];
+    }
 
     if (dep === true)
       dep = '';
@@ -261,13 +265,13 @@ function processDeps(deps, registry) {
     // jquery: github:components/jquery
     // jquery: jquery@1.5
     // -> RHS is dep
-    if (dep.indexOf(':') != -1)
+    if (dep.indexOf(':') !== -1)
       outPackage = dep;
 
-    else if (dep.indexOf('@') != -1)
+    else if (dep.indexOf('@') !== -1)
       outPackage = registry + ':' + dep;
 
-    else if (p.indexOf(':') != -1)
+    else if (p.indexOf(':') !== -1)
       outPackage = p + '@' + dep;
 
     // jquery: 1.5
@@ -308,13 +312,13 @@ exports.inject = function(pkg, depLoad) {
     throw 'Cannot inject from endpoint %' + pkg.endpoint + '% as it has no remote.';
 
   // NB remove rejectUnauthorized
-  var url = remote + (remote.substr(remote.length -1 , 1) == '/' ? '' : '/') + pkg.exactName.substr(pkg.exactName.indexOf(':') + 1) + '/.jspm.json';
-  return injecting[pkg.exactName].promise = asp(request)({
+  var url = remote + (remote.substr(remote.length -1 , 1) === '/' ? '' : '/') + pkg.exactName.substr(pkg.exactName.indexOf(':') + 1) + '/.jspm.json';
+  injecting[pkg.exactName].promise = asp(request)({
     method: 'get',
     url: url,
     rejectUnauthorized: false
   }).then(function(res) {
-    if (res.statusCode != 200)
+    if (res.statusCode !== 200)
       throw new Error('Error requesting package.json for `' + pkg.exactName + '` at %' + url + '%.');
 
     try {
@@ -328,9 +332,8 @@ exports.inject = function(pkg, depLoad) {
     depResolve(processDeps(pjson.dependencies, pjson.registry));
     return pjson;
   }, depReject);
-}
-
-
+  return injecting[pkg.exactName].promise;
+};
 
 // note if it is a symlink, we leave it unaltered
 var downloading = {};
@@ -340,7 +343,7 @@ exports.download = function(pkg, override, unlink, installDeps) {
   if (downloading[pkg.exactName]) {
     downloading[pkg.exactName].preload.then(function(depMap) {
       installDeps(depMap);
-      return depMap
+      return depMap;
     });
     downloading[pkg.exactName].postload.then(function(depMap) {
       installDeps(depMap);
@@ -360,10 +363,10 @@ exports.download = function(pkg, override, unlink, installDeps) {
   downloading[pkg.exactName] = {
     preload: getPackageConfigPromise.then(function(pjson) {
       var depMap = processDeps(pjson.dependencies, pjson.registry);
-      installDeps(depMap)
+      installDeps(depMap);
       return depMap;
     }),
-    postload: new Promise(function(resolve, reject) {
+    postload: new Promise(function(resolve) {
       postloadResolve = resolve;
     })
     .then(function(depMap) {
@@ -374,7 +377,7 @@ exports.download = function(pkg, override, unlink, installDeps) {
 
   var downloadDir = pkg.getPath();
 
-  return downloading[pkg.exactName].promise = Promise.resolve()
+  downloading[pkg.exactName].promise = Promise.resolve()
   .then(function() {
     return getDirInfo(downloadDir);
   })
@@ -389,7 +392,7 @@ exports.download = function(pkg, override, unlink, installDeps) {
 
     var pjson;
     var endpoint = ep.load(pkg.endpoint);
-    
+
     var hash;
     var fullHash;
     var meta;
@@ -435,7 +438,7 @@ exports.download = function(pkg, override, unlink, installDeps) {
       if (config.force)
         return false;
 
-      return dirInfo.hash == fullHash;
+      return dirInfo.hash === fullHash;
     })
     .then(function(_fresh) {
       fresh = _fresh;
@@ -448,7 +451,7 @@ exports.download = function(pkg, override, unlink, installDeps) {
       // ensure global cache is fresh / download if not
       return Promise.resolve(config.force ? false : getDirInfo(cacheDir))
       .then(function(cacheInfo) {
-        if (cacheInfo.hash && cacheInfo.hash == fullHash)
+        if (cacheInfo.hash && cacheInfo.hash === fullHash)
           return readJSON(path.resolve(cacheDir, '.jspm.json'))
           .then(function(_pjson) {
             pjson = _pjson;
@@ -463,18 +466,18 @@ exports.download = function(pkg, override, unlink, installDeps) {
           })
           .then(function(_pjson) {
             return derivePackageConfig(pkg, _pjson, override);
-          }, function(e) {
+          }, function() {
             throw 'Error getting package config for `' + pkg.name + '`.';
           })
           .then(function(_pjson) {
-            getPackageConfigResolve(pjson = _pjson)
+            getPackageConfigResolve(pjson = _pjson);
           }, getPackageConfigReject);
 
         return Promise.resolve(cacheDir)
         // ensure the download directory exists
         .then(asp(mkdirp))
         // clear the directory
-        .then(function() {  
+        .then(function() {
           return asp(rimraf)(cacheDir);
         })
         // create it
@@ -497,7 +500,7 @@ exports.download = function(pkg, override, unlink, installDeps) {
           .then(function(_pjson) {
             return derivePackageConfig(pkg, _pjson, override || {});
           });
-        }, function(e) {
+        }, function() {
           throw 'Error downloading `' + pkg.name + '`.';
         })
         .then(function(_pjson) {
@@ -516,7 +519,7 @@ exports.download = function(pkg, override, unlink, installDeps) {
         // in case it was linked, try and remove
         return asp(fs.unlink)(downloadDir)
         .catch(function(e) {
-          if (e.code == 'EISDIR' || e.code == 'EPERM' || e.code == 'ENOENT')
+          if (e.code === 'EISDIR' || e.code === 'EPERM' || e.code === 'ENOENT')
             return;
           throw e;
         });
@@ -542,21 +545,22 @@ exports.download = function(pkg, override, unlink, installDeps) {
       return fresh;
     });
   });
-}
+  return downloading[pkg.exactName].promise;
+};
 
 
-// like config.derivePackageConfig, but applies the 
+// like config.derivePackageConfig, but applies the
 // endpoint processPackageConfig operation as well
 function derivePackageConfig(pkg, pjson, override) {
   pjson = config.derivePackageConfig(pjson, override);
 
-  var endpoint = ep.load(pjson.registry != 'jspm' && pjson.registry || pkg.endpoint);
+  var endpoint = ep.load(pjson.registry !== 'jspm' && pjson.registry || pkg.endpoint);
   if (endpoint.processPackageConfig)
     return Promise.resolve()
     .then(function() {
       return endpoint.processPackageConfig(pjson);
     })
-    .catch(function(e) {
+    .catch(function() {
       throw 'Error processing package config for `' + pkg.name + '`.';
     });
   return pjson;
@@ -577,10 +581,10 @@ exports.derivePackageConfig = derivePackageConfig;
 exports.processPackage = function(pkg, dir, pjson, postload, isCDN) {
   // any package which takes longer than 10 seconds to process
   var timeout = setTimeout(function() {
-    ui.log('warn', 'It\'s taking a long time to process the dependencies of `' + pkg.exactName + '`.\n'
-      + 'This package may need an %ignore% property to indicate test or example folders for jspm to skip.\n');
+    ui.log('warn', 'It\'s taking a long time to process the dependencies of `' + pkg.exactName + '`.\n' +
+      'This package may need an %ignore% property to indicate test or example folders for jspm to skip.\n');
   }, 10000);
-  var endpoint = ep.load(pjson.registry != 'jspm' && pjson.registry || pkg.endpoint);
+  var endpoint = ep.load(pjson.registry !== 'jspm' && pjson.registry || pkg.endpoint);
   var deps;
   var buildErrors = [];
   var curDeps = [];
@@ -595,9 +599,9 @@ exports.processPackage = function(pkg, dir, pjson, postload, isCDN) {
         curDeps = pjson.dependencies && Object.keys(pjson.dependencies) || [];
         return endpoint.build(pjson, dir);
       })
-      .catch(function(e) {
+      .catch(function() {
         throw 'Error building package `' + pkg.name + '`.';
-      })
+      });
   })
 
   // apply build operations from the package.json
@@ -610,7 +614,7 @@ exports.processPackage = function(pkg, dir, pjson, postload, isCDN) {
       var newDepMap = processDeps(pjson.dependencies, pjson.registry);
       // remove dependencies already downloaded
       Object.keys(newDepMap).forEach(function(dep) {
-        if (curDeps.indexOf(dep) != -1)
+        if (curDeps.indexOf(dep) !== -1)
           delete newDepMap[dep];
       });
       postload(newDepMap);
@@ -646,7 +650,7 @@ exports.processPackage = function(pkg, dir, pjson, postload, isCDN) {
   .then(function() {
     clearTimeout(timeout);
   });
-}
+};
 
 exports.createMain = function(pkg, pjson, downloadDir) {
   var lastNamePart, main;
@@ -658,26 +662,26 @@ exports.createMain = function(pkg, pjson, downloadDir) {
   // create the main entry point
   .then(function() {
     lastNamePart = pkg.name.split('/').pop().split(':').pop();
-    main = typeof pjson.main == 'string' && pjson.main;
+    main = typeof pjson.main === 'string' && pjson.main;
 
     // we don't need to ensure it exists for plugin mains
     // as they can have custom locate functions
-    if (main && main.indexOf('!') != -1) {
+    if (main && main.indexOf('!') !== -1) {
       pluginMain = true;
       return true;
     }
 
     if (main) {
-      if (main.substr(0, 2) == './')
+      if (main.substr(0, 2) === './')
         main = main.substr(2);
-      if (main.substr(main.length - 3, 3) == '.js')
+      if (main.substr(main.length - 3, 3) === '.js')
         main = main.substr(0, main.length - 3);
     }
 
     main = main || 'index';
 
     // try the package.json main
-    return new Promise(function(resolve, reject) {
+    return new Promise(function(resolve) {
       mainPath = path.resolve(downloadDir, main + '.js');
       fs.exists(mainPath, resolve);
     });
@@ -687,11 +691,11 @@ exports.createMain = function(pkg, pjson, downloadDir) {
       return exists;
 
     main = lastNamePart;
-    
-    if (main.substr(main.length - 3, 3) == '.js')
+
+    if (main.substr(main.length - 3, 3) === '.js')
       main = main.substr(0, main.length - 3);
 
-    return new Promise(function(resolve, reject) {
+    return new Promise(function(resolve) {
       mainPath = path.resolve(downloadDir, main + '.js');
       fs.exists(mainPath, resolve);
     });
@@ -715,10 +719,8 @@ exports.createMain = function(pkg, pjson, downloadDir) {
     return asp(fs.readFile)(mainPath)
     .then(function(source) {
       var detected = build.detectFormat(source.toString());
-      
+
       return asp(fs.writeFile)(mainFile, getRedirectContents(detected.format, pkg.exactName + '/' + main));
     });
   });
-}
-
-
+};

--- a/lib/semver.js
+++ b/lib/semver.js
@@ -52,7 +52,7 @@ function semverCompareParsed(v1, v2) {
     var part = parts[i];
     var part1 = v1[part];
     var part2 = v2[part];
-    if (part1 == part2)
+    if (part1 === part2)
       continue;
     if (isNaN(part1))
       return -1;
@@ -70,13 +70,13 @@ function semverCompareParsed(v1, v2) {
     return -1;
 
   // prerelease comparison
-  for (var i = 0, l = Math.min(v1.pre.length, v2.pre.length); i < l; i++) {
-    if (v1.pre[i] == v2.pre[i])
+  for (var j = 0, l = Math.min(v1.pre.length, v2.pre.length); j < l; j++) {
+    if (v1.pre[j] === v2.pre[j])
       continue;
 
-    var isNum1 = v1.pre[i].match(numRegEx);
-    var isNum2 = v2.pre[i].match(numRegEx);
-    
+    var isNum1 = v1.pre[j].match(numRegEx);
+    var isNum2 = v2.pre[j].match(numRegEx);
+
     // numeric has lower precedence
     if (isNum1 && !isNum2)
       return -1;
@@ -85,12 +85,12 @@ function semverCompareParsed(v1, v2) {
 
     // compare parts
     if (isNum1 && isNum2)
-      return toInt(v1.pre[i]) > toInt(v2.pre[i]) ? 1 : -1;
+      return toInt(v1.pre[j]) > toInt(v2.pre[j]) ? 1 : -1;
     else
-      return v1.pre[i] > v2.pre[i] ? 1 : -1;
+      return v1.pre[j] > v2.pre[j] ? 1 : -1;
   }
 
-  if (v1.pre.length == v2.pre.length)
+  if (v1.pre.length === v2.pre.length)
     return 0;
 
   // more pre-release fields win if equal
@@ -105,10 +105,10 @@ function matchParsed(range, version) {
   var rangeVersion = range.version;
 
   if (rangeVersion.tag)
-    return rangeVersion.tag == version.tag;
+    return rangeVersion.tag === version.tag;
 
   // if the version is less than the range, it's not a match
-  if (semverCompareParsed(rangeVersion, version) == 1)
+  if (semverCompareParsed(rangeVersion, version) === 1)
     return false;
 
   // now we just have to check that the version isn't too high for the range
@@ -118,32 +118,32 @@ function matchParsed(range, version) {
   // if the version has a prerelease, ensure the range version has a prerelease in it
   // and that we match the range version up to the prerelease exactly
   if (version.pre) {
-    if (!(rangeVersion.major == version.major && rangeVersion.minor == version.minor && rangeVersion.patch == version.patch))
+    if (!(rangeVersion.major === version.major && rangeVersion.minor === version.minor && rangeVersion.patch === version.patch))
       return false;
-    return range.semver || range.fuzzy || rangeVersion.pre.join('.') == version.pre.join('.');
+    return range.semver || range.fuzzy || rangeVersion.pre.join('.') === version.pre.join('.');
   }
 
   // check semver range
   if (range.semver) {
     // ^0
-    if (rangeVersion.major == 0 && isNaN(rangeVersion.minor))
+    if (rangeVersion.major === 0 && isNaN(rangeVersion.minor))
       return version.major < 1;
     // ^1..
     else if (rangeVersion.major >= 1)
-      return rangeVersion.major == version.major;
+      return rangeVersion.major === version.major;
     // ^0.1, ^0.2
     else if (rangeVersion.minor >= 1)
-      return version.major == 0 && rangeVersion.minor == version.minor;
+      return version.major === 0 && rangeVersion.minor === version.minor;
     // ^0.0.x falls down to exact match below
   }
 
   // check fuzzy range
   if (range.fuzzy)
-    return version.major == rangeVersion.major && version.minor < (rangeVersion.minor || 0) + 1;
+    return version.major === rangeVersion.major && version.minor < (rangeVersion.minor || 0) + 1;
 
   // exact match
   // eg 001.002.003 matches 1.2.3
-  return !rangeVersion.pre && rangeVersion.major == version.major && rangeVersion.minor == version.minor && rangeVersion.patch == version.patch;
+  return !rangeVersion.pre && rangeVersion.major === version.major && rangeVersion.minor === version.minor && rangeVersion.patch === version.patch;
 }
 
 /*
@@ -154,9 +154,9 @@ function matchParsed(range, version) {
 function parseRange(range) {
   var rangeObj = {};
 
-  ((rangeObj.semver = range.substr(0, 1) == '^') 
-      || (rangeObj.fuzzy = range.substr(0, 1) == '~')
-  ) && (range = range.substr(1));
+  ((rangeObj.semver = range.substr(0, 1) === '^') ||
+      (rangeObj.fuzzy = range.substr(0, 1) === '~')
+  ) && (range = range.substr(1)); // jshint ignore:line
 
   var rangeVersion = rangeObj.version = parseSemver(range);
 
@@ -186,12 +186,12 @@ exports.semverRegEx = semverRegEx;
 
 exports.compare = function(v1, v2) {
   return semverCompareParsed(parseSemver(v1), parseSemver(v2));
-}
+};
 
 exports.match = function match(range, version) {
   // supported range types:
   // 0.2, 1, ~1.2.3, ^1.2.3, ^0.4.3-alpha.1
-  if (range == '' || range == '*')
+  if (range === '' || range === '*')
     return true;
   return matchParsed(parseRange(range), parseSemver(version));
-}
+};

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -16,18 +16,21 @@
 
 var Promise = require('rsvp').Promise;
 
+var apiResolver;
+var logging = true;
+var logBuffer = '';
+var logged = false;
+var cli = module.exports;
+
 // if storing any logs, dump them on exit
 process.on('exit', function() {
   if (logBuffer && !apiResolver)
     console.log(logBuffer);
-})
+});
 
-var cli = module.exports;
-
-var apiResolver;
 exports.setResolver = function(resolver) {
   apiResolver = resolver;
-}
+};
 
 // use the default option in all prompts
 // throws an error for prompts that don't take a default
@@ -36,41 +39,8 @@ exports.useDefaults = function(_useDefaults) {
   if (_useDefaults === undefined)
     _useDefaults = true;
   useDefaults = _useDefaults;
-}
+};
 
-
-var logging = true;
-var logBuffer = '';
-var logged = false;
-var log = exports.log = function(type, msg) {
-  if (apiResolver)
-    return apiResolver.emit('log', type, msg);
-
-  logged = true;
-  if (arguments.length == 1) {
-    msg = type;
-    type = null;
-  }
-
-  if (typeof(msg) !== 'string')
-    msg = String(msg);
-
-  if (type)
-    msg = format[type](msg);
-
-  if (logging)
-    return console.log(msg);
-  logBuffer += msg + '\n';
-}
-
-function moduleMsg(msg, color) {
-  return (color || '\033[0m')
-    + msg
-      .replace(/(\s|\`|^)%([^%\n]+)%/g, '$1\033[0m\033[1m$2\033[0m' + color || '')
-      .replace(/(\s|^)\`([^\`\n]+)\`/g, '$1\033[36m$2\033[0m' + color || '')
-      .replace(/\n\r?( {0,4}\w)/g, '\n     $1')
-    + '\033[0m';
-}
 var format = exports.format = {
   q: function(msg, opt) {
     return moduleMsg(msg, '') + '' + (opt ? ' [' + opt + ']' : '') + '\033[39m:\033[0m ';
@@ -89,6 +59,36 @@ var format = exports.format = {
   }
 };
 
+exports.log = function(type, msg) {
+  if (apiResolver)
+    return apiResolver.emit('log', type, msg);
+
+  logged = true;
+  if (arguments.length === 1) {
+    msg = type;
+    type = null;
+  }
+
+  if (typeof(msg) !== 'string')
+    msg = String(msg);
+
+  if (type)
+    msg = format[type](msg);
+
+  if (logging)
+    return console.log(msg);
+  logBuffer += msg + '\n';
+};
+
+function moduleMsg(msg, color) {
+  return (color || '\033[0m') +
+    msg
+    .replace(/(\s|\`|^)%([^%\n]+)%/g, '$1\033[0m\033[1m$2\033[0m' + color || '')
+    .replace(/(\s|^)\`([^\`\n]+)\`/g, '$1\033[36m$2\033[0m' + color || '')
+    .replace(/\n\r?( {0,4}\w)/g, '\n     $1') +
+    '\033[0m';
+}
+
 var inputQueue = [];
 var confirm = exports.confirm = function(msg, def) {
   if (useDefaults) {
@@ -98,8 +98,8 @@ var confirm = exports.confirm = function(msg, def) {
     return Promise.resolve(def);
   }
 
-  if (apiResolver) 
-    return new Promise(function(resolve, reject) {
+  if (apiResolver)
+    return new Promise(function(resolve) {
       apiResolver.emit('prompt', {
         type: 'confirm',
         message: msg,
@@ -128,7 +128,7 @@ var confirm = exports.confirm = function(msg, def) {
     else
       return confirm(msg, def);
   });
-}
+};
 
 exports.input = function(msg, def, disableOutput, queue) {
   if (useDefaults) {
@@ -137,7 +137,7 @@ exports.input = function(msg, def, disableOutput, queue) {
   }
 
   if (apiResolver)
-    return new Promise(function(resolve, reject) {
+    return new Promise(function(resolve) {
       apiResolver.emit('prompt', {
         type: 'input',
         message: msg,
@@ -147,14 +147,14 @@ exports.input = function(msg, def, disableOutput, queue) {
       });
     });
 
-  if (arguments.length == 2)
+  if (arguments.length === 2)
     disableOutput = false;
 
   return new Promise(function(resolve, reject) {
     if (!logging && !queue)
       return inputQueue.push({
         args: [msg, def, disableOutput, true],
-        resolve: resolve, 
+        resolve: resolve,
         reject: reject
       });
 
@@ -169,7 +169,7 @@ exports.input = function(msg, def, disableOutput, queue) {
     var inputVal = '';
     process.stdin.on('data', function(chunk) {
       var lastChar = chunk.substr(chunk.length - 1, 1);
-      if (lastChar == '\n' || lastChar == '\r' || lastChar == '\u0004') {
+      if (lastChar === '\n' || lastChar === '\r' || lastChar === '\u0004') {
         if (disableOutput)
           process.stdin.setRawMode(false);
         process.stdin.pause();
@@ -195,5 +195,5 @@ exports.input = function(msg, def, disableOutput, queue) {
       inputVal += chunk;
     });
 
-  });  
-}
+  });
+};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "registry": "npm",
   "devDependencies": {
+    "jshint": "~2.6.1",
     "mocha": "~1.17.1"
   },
   "repository": {
@@ -35,7 +36,9 @@
     "jspm": "./jspm.js"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "npm run jshint && npm run mocha",
+    "mocha": "mocha",
+    "jshint": "jshint api.js cli.js jspm.js lib test"
   },
   "bugs": {
     "url": "https://github.com/jspm/jspm/issues"

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,12 @@
+{
+    "maxerr"        : 50,       // {int} Maximum error before stopping
+
+    // Enforcing
+    "indent"        : 2,        // {int} Number of spaces to use for indentation
+    "quotmark"      : "single",
+    "strict"        : false,     // true: Requires all functions run in ES5 Strict Mode
+
+    // Environments
+    "mocha"         : true,   // Mocha
+    "node"          : true    // Node.js
+}

--- a/test/api.js
+++ b/test/api.js
@@ -5,7 +5,7 @@ api.setPackagePath('testlibs');
 suite('API Calls', function() {
   test('Normalize', function(done) {
     api.normalize('jquery').then(function(normalized) {
-      assert(normalized == 'github:components/jquery@2.1.3');
+      assert(normalized === 'github:components/jquery@2.1.3');
       done();
     }, done);
   });
@@ -20,5 +20,3 @@ suite('API Calls', function() {
     }, done);
   });
 });
-
-

--- a/test/package.js
+++ b/test/package.js
@@ -97,7 +97,5 @@ suite('Process Dependencies', function() {
 
   test('processDeps convergence', function() {
     assert.deepEqual(serialize(processDeps(processDeps({ 'test': '1.2.3' }, 'npm'), 'npm')), { 'test': 'npm:test@1.2.3' });
-  })
+  });
 });
-
-


### PR DESCRIPTION
- Added jshint linter to `npm test`
- Added editorconfig
- Minor code refactoring as discussed in https://github.com/jspm/jspm-cli/commit/3d3fb0b47c6f8850c6cad3834e274cc2a51364a9#commitcomment-9734519
 
So far everything works as expected and I hope that I didn't introduce due to the many changes some unwanted bugs. Most of the linter warnings have been of type `==` vs `===` or missing `;` at the end of the lines. The diff shows also many modified lines due to trimming of trailing whitespaces.

Futhermore I'd recommend to active `qurly` so that each block or scope requires `{}` to avoid easy to overlook typos like:

```javascript
if (Error)
  console.log('Error');
return Error;
// If no error continue here ...
```

To avoid annoying build errors after pusing your code to the upstream because of some linter errors there are helpfull plugins/packages for Sublime and Atom to give you direct feedback while typing. It has only very little impact on the performance of the Editor so I'm always using it. For Atom I've installed `linter`and `linter-jshint`. Also I've installed the `editorconfig`package. 

As next step I wanted to test also [ESLint](http://eslint.org/) once as it uses an AST for linting which gives better results compared to JSHint which analyzes line for line though ESLint is x2-x3 times slower.