### PR TITLE
Prefix private fields with __

### DIFF
--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -25,6 +25,7 @@ var PackageName = require('./package-name');
 var alphabetize = require('../common').alphabetize;
 var stringify = require('../common').stringify;
 var ui = require('../ui');
+var extractObj = require('./utils').extractObj;
 
 /*
  * Loader Configuration Class
@@ -236,36 +237,6 @@ EndpointPath.prototype.setRemote = function() {
 }
 EndpointPath.prototype.write = function() {
   return this.path;
-}
-
-// convert structured configuration into a plain object
-// by calling the .write() methods of structured classes
-// properties ending in _ are considered private
-// NB may be less convoluted just to make these explicit
-function extractObj(obj, host) {
-  var out = {};
-  for (var p in obj) {
-    if (!obj.hasOwnProperty(p))
-      continue;
-    if (p.substr(p.length - 1, 1) ==  '_')
-      continue;
-
-    var val = obj[p], writeValue;
-    if (typeof val == 'string')
-      out[p] = val;
-    else if (typeof val == 'object') {
-      if (typeof val.write == 'function')
-        out[p] = val.write();
-      else if (val instanceof Array)
-        out[p] = val;
-      else
-        out[p] = extractObj(val, {});
-    }
-  }
-  for (var p in host)
-    if (!(p in out))
-      out[p] = host[p];
-  return out;
 }
 
 Config.prototype.write = function() {

--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -46,15 +46,15 @@ var extractObj = require('./utils').extractObj;
 // and endpoint is a path rule ending in ':*'
 var endpointRegEx = /\:\*$/;
 function Config(fileName) {
-  this.fileName_ = fileName;
+  this.__fileName = fileName;
 }
 Config.prototype.read = function(prompts) {
-  if (this.read_)
+  if (this.__read)
     throw "Config already read";
-  this.read_ = true;
+  this.__read = true;
 
   var self = this;
-  return asp(fs.readFile)(this.fileName_)
+  return asp(fs.readFile)(this.__fileName)
   .catch(function() {
     return '';
   })
@@ -87,7 +87,7 @@ Config.prototype.read = function(prompts) {
     return cfg;
   })
   .then(function(cfg) {
-    self.originalConfig_ = cfg;
+    self.__originalConfig = cfg;
 
     self.baseURL = cfg.baseURL;
 
@@ -202,7 +202,7 @@ Config.prototype.ensureEndpoint = function(endpointName, remote) {
 
 // return the loader configuration for a server loading use
 Config.prototype.getConfig = function() {
-  var cfg = extend({}, this.originalConfig_);
+  var cfg = extend({}, this.__originalConfig);
 
   // set all endpoint paths to be local paths
   cfg.paths = extend({}, cfg.paths);
@@ -241,7 +241,7 @@ EndpointPath.prototype.write = function() {
 
 Config.prototype.write = function() {
   // extract over original config to keep initial values
-  var cfg = extractObj(this, this.originalConfig_);
+  var cfg = extractObj(this, this.__originalConfig);
 
   // allow * path to be overridden
   if (!cfg.paths['*'])
@@ -317,7 +317,7 @@ Config.prototype.write = function() {
   if (hasProperties(versions))
     configContent += 'System.config(' + stringify({ versions: versions }) + ');' + config.newLine + config.newLine;
 
-  return asp(fs.writeFile)(this.fileName_, configContent);
+  return asp(fs.writeFile)(this.__fileName, configContent);
 }
 module.exports = Config;
 

--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -58,21 +58,21 @@ function PackageJSON(fileName) {
 }
 
 PackageJSON.prototype.read = function(prompts) {
-  if (this.read_)
+  if (this.__read)
     throw "Package.json file already read";
 
-  this.read_ = true;
+  this.__read = true;
   var self = this;
   var pjson;
 
   return readJSON(this.fileName)
   .then(function(_pjson) {
     self.originalPjson = _pjson;
-    
+
     self.jspmPrefix = true;
     if (_pjson.registry && !_pjson.jspm)
       self.jspmPrefix = false;
-    
+
     // derive the jspm config from the 'jspm' property in the package.json
     // also sets the registry property if dependencies are jspm-prefixed
     pjson = config.derivePackageConfig(_pjson);
@@ -112,7 +112,7 @@ PackageJSON.prototype.read = function(prompts) {
 
     defaults.configFile = path.resolve(self.baseURL, 'config.js');
     self.configFile = pjson.configFile && path.resolve(self.dir, pjson.configFile) || defaults.configFile;
-    
+
     self.format = pjson.format;
     self.map = extend({}, pjson.map || {});
 
@@ -120,7 +120,7 @@ PackageJSON.prototype.read = function(prompts) {
     self.useJSExtensions = pjson.useJSExtensions;
 
     self.buildConfig = extend({}, pjson.buildConfig || {});
-    
+
     return prompts;
   });
 }
@@ -185,7 +185,7 @@ PackageJSON.prototype.write = function() {
     }
     else
       depValue = dep.exactName;
-    
+
     pjson.dependencies[d] = depValue;
   }
   pjson.dependencies = alphabetize(pjson.dependencies);

--- a/lib/config/utils.js
+++ b/lib/config/utils.js
@@ -7,7 +7,7 @@ module.exports.extractObj = function extractObj(obj, host) {
   for (var p in obj) {
     if (!obj.hasOwnProperty(p))
       continue;
-    if (p.substr(p.length - 1, 1) ==  '_')
+    if (p.substr(0, 2) ==  '__')
       continue;
 
     var val = obj[p];

--- a/lib/config/utils.js
+++ b/lib/config/utils.js
@@ -1,0 +1,29 @@
+// convert structured configuration into a plain object
+// by calling the .write() methods of structured classes
+// properties ending in _ are considered private
+// NB may be less convoluted just to make these explicit
+module.exports.extractObj = function extractObj(obj, host) {
+  var out = {};
+  for (var p in obj) {
+    if (!obj.hasOwnProperty(p))
+      continue;
+    if (p.substr(p.length - 1, 1) ==  '_')
+      continue;
+
+    var val = obj[p];
+    if (typeof val == 'string')
+      out[p] = val;
+    else if (typeof val == 'object') {
+      if (typeof val.write == 'function')
+        out[p] = val.write();
+      else if (val instanceof Array)
+        out[p] = val;
+      else
+        out[p] = extractObj(val, {});
+    }
+  }
+  for (var p in host)
+    if (!(p in out))
+      out[p] = host[p];
+  return out;
+};

--- a/test/loader-utils.js
+++ b/test/loader-utils.js
@@ -1,0 +1,42 @@
+/* global suite, test, assert */
+
+var extractObj = require('../lib/config/utils').extractObj;
+
+suite('Loader util', function() {
+  suite('extractObj', function () {
+    test('copy strings and arrays as is', function() {
+      assert.deepEqual(extractObj({
+        str:'yes',
+        arr: [{wow_:true}]
+      }), {
+        str:'yes',
+        arr: [{wow_:true}]
+      });
+    });
+
+    test('skip booleans', function() {
+      assert.deepEqual(extractObj({read:true}), {});
+    });
+
+    test('call write method on objects', function() {
+      var called = false;
+      var obj = { k: { write: function() { called=true; } } };
+      extractObj(obj);
+      assert.ok(called);
+    });
+
+    test('filters private fields', function() {
+      assert.deepEqual(extractObj({read_:'yes'}), {});
+    });
+
+    test('copy fields from host object', function() {
+      assert.deepEqual(extractObj({}, {host:'yes'}), {host:'yes'});
+      assert.deepEqual(extractObj({}, {host_:'yes'}), {host_:'yes'});
+    });
+
+    test('traverse object', function() {
+      assert.deepEqual(extractObj({field:{obj:'yes'}}), {field:{obj:'yes'}});
+      assert.deepEqual(extractObj({field:{obj_:'yes'}}), {field:{}});
+    });
+  });
+});

--- a/test/loader-utils.js
+++ b/test/loader-utils.js
@@ -7,10 +7,10 @@ suite('Loader util', function() {
     test('copy strings and arrays as is', function() {
       assert.deepEqual(extractObj({
         str:'yes',
-        arr: [{wow_:true}]
+        arr: [{__wow:true}]
       }), {
         str:'yes',
-        arr: [{wow_:true}]
+        arr: [{__wow:true}]
       });
     });
 
@@ -26,17 +26,17 @@ suite('Loader util', function() {
     });
 
     test('filters private fields', function() {
-      assert.deepEqual(extractObj({read_:'yes'}), {});
+      assert.deepEqual(extractObj({__read:'yes'}), {});
     });
 
     test('copy fields from host object', function() {
       assert.deepEqual(extractObj({}, {host:'yes'}), {host:'yes'});
-      assert.deepEqual(extractObj({}, {host_:'yes'}), {host_:'yes'});
+      assert.deepEqual(extractObj({}, {__host:'yes'}), {__host:'yes'});
     });
 
     test('traverse object', function() {
       assert.deepEqual(extractObj({field:{obj:'yes'}}), {field:{obj:'yes'}});
-      assert.deepEqual(extractObj({field:{obj_:'yes'}}), {field:{}});
+      assert.deepEqual(extractObj({field:{__obj:'yes'}}), {field:{}});
     });
   });
 });


### PR DESCRIPTION
Since [naming conventions](https://docs.npmjs.com/files/package.json) on npm packages says, that `Any name with non-url-safe characters will be rejected. Also, it can't start with a dot or an underscore.` it would be logical to prefix private fields with `_` so they will not be filtered by `extractObj`.