### PR TITLE
Fix EINVAL rename error

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -141,7 +141,7 @@ exports.collapseLibDir = function(dir, subDir) {
   var tmpDir = path.resolve(dir, '..', '.tmp-' + dir.split(path.sep).pop());
   
   // move subDir to tmpDir
-  return asp(fs.rename)(dir + path.sep + subDir, tmpDir)
+  return asp(fs.rename)(path.normalize(dir + path.sep + subDir), tmpDir)
 
   // remove everything in dir
   .then(function() {


### PR DESCRIPTION
This happens, when `subDir` is equal `.` - seems like node does not handle path with dot on end well.