### PR TITLE
Removal of empty directories after installation

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -170,7 +170,7 @@ exports.filterIgnoreAndFiles = function(dir, ignore, files) {
       // do removal
       return Promise.all(removeDirs.map(function(dir) {
         return asp(fs.rmdir)(dir).catch(function(e) {
-          if (e.code === 'EPERM' || e.code === 'EISFILE' || e.code === 'ENOENT')
+          if (e.code === 'EPERM' || e.code === 'EISFILE' || e.code === 'ENOENT' || e.code === 'ENOTEMPTY')
             return;
           throw e;
         });

--- a/lib/build.js
+++ b/lib/build.js
@@ -130,7 +130,7 @@ exports.filterIgnoreAndFiles = function(dir, ignore, files) {
 
       //strip base dir from allFiles first to correctly compare it with the removeFiles
       for (var i = allFiles.length - 1; i >= 0; i--) {
-        if(allFiles[i].indexOf(dir+"/" === 0)) allFiles[i] = allFiles[i].substr(dir.length+1);
+        if(allFiles[i].indexOf(dir+'/' === 0)) allFiles[i] = allFiles[i].substr(dir.length+1);
       }
 
       // create object listing directories by file counts from the remaining files
@@ -151,15 +151,15 @@ exports.filterIgnoreAndFiles = function(dir, ignore, files) {
       var removeDirs = [];
       Object.keys(dirFileCount).forEach(function(rdir) {
         if (rdir!=='' && dirFileCount[rdir] === 0)
-          removeDirs.push(dir+"/"+rdir);
+          removeDirs.push(dir+'/'+rdir);
       });
 
       //add files from the removeFiles array that look like directories (do not have file extension)
       //this is needed to pickup empty directories inside empty directories
       removeFiles.forEach(function(file) {
-        var dotpos = file.lastIndexOf(".");
-        if(dotpos==-1 || dotpos > file.lastIndexOf("/")){
-          removeDirs.push(dir+"/"+file);
+        var dotpos = file.lastIndexOf('.');
+        if(dotpos===-1 || dotpos > file.lastIndexOf('/')){
+          removeDirs.push(dir+'/'+file);
         }
       });
       

--- a/lib/build.js
+++ b/lib/build.js
@@ -124,7 +124,59 @@ exports.filterIgnoreAndFiles = function(dir, ignore, files) {
           return;
         throw e;
       });
-    }));
+    }))
+    // remove empty folders
+    .then(function() {
+
+      //strip base dir from allFiles first to correctly compare it with the removeFiles
+      for (var i = allFiles.length - 1; i >= 0; i--) {
+        if(allFiles[i].indexOf(dir+"/" === 0)) allFiles[i] = allFiles[i].substr(dir.length+1);
+      }
+
+      // create object listing directories by file counts from the remaining files
+      var dirFileCount = {};
+      //var dirFileRemainCount = {};
+      allFiles.forEach(function(file) {
+        var dir = file.substr(0, file.lastIndexOf('/'));
+        dirFileCount[dir] = dirFileCount[dir] + 1 || 1;
+      });
+
+      // decrement file counts from removeFiles
+      removeFiles.forEach(function(file) {
+        var dir = file.substr(0, file.lastIndexOf('/'));
+        dirFileCount[dir] = dirFileCount[dir] - 1;
+      });
+
+      // now go through and populate removeDirs
+      var removeDirs = [];
+      Object.keys(dirFileCount).forEach(function(rdir) {
+        if (rdir!=='' && dirFileCount[rdir] === 0)
+          removeDirs.push(dir+"/"+rdir);
+      });
+
+      //add files from the removeFiles array that look like directories (do not have file extension)
+      //this is needed to pickup empty directories inside empty directories
+      removeFiles.forEach(function(file) {
+        var dotpos = file.lastIndexOf(".");
+        if(dotpos==-1 || dotpos > file.lastIndexOf("/")){
+          removeDirs.push(dir+"/"+file);
+        }
+      });
+      
+      // must reverse array to remove subdirs first
+      // otherwise will throw an error if trying to remove a directory which has an empty directory in it
+      removeDirs.reverse();
+
+      // do removal
+      return Promise.all(removeDirs.map(function(dir) {
+        return asp(fs.rmdir)(dir).catch(function(e) {
+          if (e.code === 'EPERM' || e.code === 'EISFILE' || e.code === 'ENOENT')
+            return;
+          throw e;
+        });
+      }));
+    });
+
   });
 };
 


### PR DESCRIPTION
you wer're right in the last PR , it was throwing an error when an empty directory had an empty directory in it in case `ignore` was used. Please have a look at my take on the solution.
i had to add files that look like directories from the removeFiles array.
This could be a problem for files that look like directories, but i've added a catch for the `EISFILE` error of the rmdir function.