### PR TITLE
fix for jspm link when a node_modules directory is present

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -86,7 +86,7 @@ exports.link = function(name, dir, force) {
     // copy the files to the local cache folder (skip node_modules and .git directories as this can cause the process to timeout)
     .then(function() {
       return asp(ncp)(dir, linkDir,{filter:function(filename){
-        return (filename !== path.resolve(dir,'node_modules') && filename !== path.resolve(dir,'.git'))
+        return (filename !== path.resolve(dir,'node_modules') && filename !== path.resolve(dir,'.git'));
       }});
     })
     // run the jspm operations on the folder to process it

--- a/lib/link.js
+++ b/lib/link.js
@@ -83,9 +83,11 @@ exports.link = function(name, dir, force) {
 
       return asp(mkdirp)(linkDir);
     })
-    // copy the files to the local cache folder
+    // copy the files to the local cache folder (skip node_modules and .git directories as this can cause the process to timeout)
     .then(function() {
-      return asp(ncp)(dir, linkDir);
+      return asp(ncp)(dir, linkDir,{filter:function(filename){
+        return (filename !== path.resolve(dir,"node_modules") && filename !== path.resolve(dir,".git"))
+      }});
     })
     // run the jspm operations on the folder to process it
     .then(function() {

--- a/lib/link.js
+++ b/lib/link.js
@@ -86,7 +86,7 @@ exports.link = function(name, dir, force) {
     // copy the files to the local cache folder (skip node_modules and .git directories as this can cause the process to timeout)
     .then(function() {
       return asp(ncp)(dir, linkDir,{filter:function(filename){
-        return (filename !== path.resolve(dir,"node_modules") && filename !== path.resolve(dir,".git"))
+        return (filename !== path.resolve(dir,'node_modules') && filename !== path.resolve(dir,'.git'))
       }});
     })
     // run the jspm operations on the folder to process it


### PR DESCRIPTION
when i link a local package that has a node_modules in it with a lot of files, the link process will often timeout and fail.
also it is not needed to copy the node_modules folder for each linked package as this can be huge.
on that note i also excluded the .git directory which is also not needed in the linked package. (maybe it should also ignore jspm_packages ?)