### PR TITLE
Keep registry in jspm section

### DIFF
--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -131,7 +131,7 @@ PackageJSON.prototype.write = function() {
     delete pjson.jspm;
     pjson.registry = this.registry || globalConfig.config.registry;
   }
-  else if (this.registry !== 'jspm') {
+  else {
     pjson.registry = this.registry;
   }
 


### PR DESCRIPTION
Without registry in `jspm` section we got `npm` endpoint resolving, instead of `jspm`. This breaks packages, that published in npm with `jspm` dependency format inside.

Closes #559 