### PR TITLE
Update SystemJS to 0.15.0

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -37,7 +37,7 @@ var core = module.exports;
 // we always download the latest semver compatible version
 var lVersions = {
   esml: '^0.14.0',
-  system: '^0.14.0',
+  system: '^0.15.0',
   traceur: '^0.0.84',
   babel: '^4.1.1'
 };

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "rimraf": "~2.2.2",
     "rsvp": "~3.0.16",
     "semver": "~4.3.0",
-    "systemjs": "^0.14.1",
-    "systemjs-builder": "~0.9.0",
+    "systemjs": "^0.15.0",
+    "systemjs-builder": "~0.9.1",
     "traceur": "0.0.82",
     "uglify-js": "~2.4.16"
   },


### PR DESCRIPTION
jspm was installing incompatible versions of SystemJs and Babel +
babel-runtime, resulting in broken files.

See systemjs/systemjs#374 and babel/babel#1022 for the conversation
chain. See also https://github.com/cmaher/systemjs-babel-runtime, which breaks with the latest
version of jspm and is fixed with this commit.

I'm not sure what tests to update with this... are there sample projects that you test against?