### PR TITLE
fix(shim-commonjs): fix to stop format being hard-set to 'global' when a...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ testlibs/build.js.map
 testlibs/.DS_Store
 npm-debug.log
 test/outputs
+!test/fixtures/**/node_modules

--- a/lib/build.js
+++ b/lib/build.js
@@ -417,18 +417,20 @@ exports.compileDir = function(dir, options) {
             if (typeof curShim.deps === 'string')
               curShim.deps = [curShim.deps];
 
-            var depStr = '"format global";' + nl;
+            var depStr = '';
             if (curShim.deps)
               for (var i = 0; i < curShim.deps.length; i++)
                 depStr += '"deps ' + curShim.deps[i] + '";' + nl;
 
-            if (curShim.exports)
+            if (curShim.exports) {
+              depStr = '"format global";' + nl + depStr;
               depStr += '"exports ' + curShim.exports + '";' + nl;
+            }
 
             changed = true;
             source = depStr + source;
 
-            return true;
+            return curShim.exports;
           })
 
           // add any format hint if provided
@@ -437,9 +439,9 @@ exports.compileDir = function(dir, options) {
           // NB all regexs should apply after removing comments
           // also ideally format injection should be post-minification
           // in case of minification quirks
-          .then(function(shimmed) {
-            // don't add format if already shimmed!
-            if (shimmed)
+          .then(function(isglobal) {
+            // don't add format if already set!
+            if (isglobal)
               return;
 
             var detected = detectFormat(source);

--- a/test/build.js
+++ b/test/build.js
@@ -1,0 +1,178 @@
+/* */
+var build = require('../lib/build');
+var asp = require('rsvp').denodeify;
+var path = require('path');
+var fs = require('fs');
+
+/*
+   options.format
+   options.shim
+   options.dependencies
+   options.map
+   options.removeJSExtensions
+   options.transpile
+   options.minify
+   options.sourceURLBase
+   options.alwaysIncludeFormat
+*/
+
+suite('compileDir', function() {
+   /* copy the fixtures to 'output' dir so we can mangle them there */
+   var ncp = require('ncp').ncp;
+   ncp.limit = 16;
+   ncp(path.join(__dirname, 'fixtures/compile/'), path.join(__dirname, './outputs/compile'), function (err) {
+      if (err) return console.error(err);
+      console.log('copied compileDir fixtures to output');
+   });
+
+   test('Allows shimming of commonjs modules and when shim is defined as array', function(done) {
+      var inputDir = path.join(__dirname, 'outputs/compile/shim/cjs/');
+      var outputFile = path.join(__dirname, 'outputs/compile/shim/cjs/entry.js');
+      var options = {
+         format: undefined,
+         dependencies: undefined,
+         shim: {
+            'entry': [ 'cjs-dep' ]
+         },
+         map: undefined,
+         removeJSExtensions: undefined,
+         transpile: undefined,
+         minify: undefined,
+         sourceURLBase: inputDir,
+         alwaysIncludeFormat: undefined
+      };
+      build.compileDir(inputDir, options)
+         .then(function() {
+            return asp(fs.readFile)(outputFile, 'utf8');
+         })
+         .then(function(source) {
+            //console.log(source);
+            assert(source.match(/\s*"format cjs";\s*/));
+            assert(source.match(/\s*"deps cjs-dep";\s*/));
+         })
+         .then(done, done);
+   });
+
+   test('Forces format to global if shim export is configured', function(done) {
+      var inputDir = path.join(__dirname, 'outputs/compile/shim/global/');
+      var outputFile = path.join(__dirname, 'outputs/compile/shim/global/entry.js');
+      var options = {
+         format: undefined,
+         dependencies: undefined,
+         shim: {
+            'entry': {
+               deps: [ 'global-dep' ],
+               exports: 'birmingham'
+            }
+         },
+         map: undefined,
+         removeJSExtensions: undefined,
+         transpile: undefined,
+         minify: undefined,
+         sourceURLBase: inputDir,
+         alwaysIncludeFormat: undefined
+      };
+      build.compileDir(inputDir, options)
+         .then(function() {
+            return asp(fs.readFile)(outputFile, 'utf8');
+         })
+         .then(function(source) {
+            //console.log(source);
+            assert(source.match(/\s*"format global";\s*/));
+            assert(source.match(/\s*"exports birmingham";\s*/));
+            assert(source.match(/\s*"deps global-dep";\s*/));
+         })
+         .then(done, done);
+   });
+
+   test('Does not process files in node_modules or jspm_packages (when linking)', function(done) {
+      var inputDir = path.join(__dirname, 'outputs/compile/glob/cjs');
+      var nodeFile = path.join(__dirname, 'outputs/compile/glob/cjs/node_modules/ignoreme.js');
+      var jspmFile = path.join(__dirname, 'outputs/compile/glob/cjs/jspm_packages/ignoreme2.js');
+      var entryFile = path.join(__dirname, 'outputs/compile/glob/cjs/entry.js');
+      var options = {
+         format: undefined,
+         shim: undefined,
+         dependencies: undefined,
+         map: undefined,
+         removeJSExtensions: undefined,
+         transpile: undefined,
+         minify: undefined,
+         sourceURLBase: inputDir,
+         alwaysIncludeFormat: undefined
+      };
+      build.compileDir(inputDir, options)
+         .then(function() {
+            return asp(fs.readFile)(nodeFile, 'utf8');
+         })
+         .then(function(source) {
+            assert(source == 'var seeme = false;\nmodule.exports = seeme;');
+         })
+         .then(function() {
+            return asp(fs.readFile)(jspmFile, 'utf8');
+         })
+         .then(function(source) {
+            assert(source == 'window.seeme = false;');
+         })
+         .then(function() {
+            return asp(fs.readFile)(entryFile, 'utf8');
+         })
+         .then(function(source) {
+            assert(source.match(/\s*"format cjs";\s*/));
+         })
+         .then(done, done);
+   });
+
+   test('Shims files with non-js extensions', function(done) {
+      var inputDir = path.join(__dirname, 'outputs/compile/shim/es6/');
+      var outputFile = path.join(__dirname, 'outputs/compile/shim/es6/entry.es6');
+      var options = {
+         format: undefined,
+         shim: {
+            'entry.es6': [ 'entry.css' ]
+         },
+         dependencies: undefined,
+         map: undefined,
+         removeJSExtensions: undefined,
+         transpile: undefined,
+         minify: undefined,
+         sourceURLBase: inputDir,
+         alwaysIncludeFormat: undefined
+      };
+      build.compileDir(inputDir, options)
+         .then(function() {
+            return asp(fs.readFile)(outputFile, 'utf8');
+         })
+         .then(function(source) {
+            //console.log(source);
+            assert(source.match(/\s*"format es6";\s*/));
+            assert(source.match(/\s*"deps entry.css";\s*/));
+         })
+         .then(done, done);
+   });
+
+   test('Detected format does not override specified format', function(done) {
+      var inputDir = path.join(__dirname, 'outputs/compile/format/cjs');
+      var outputFile = path.join(__dirname, 'outputs/compile/format/cjs/entry.js');
+      var options = {
+         format: 'global',
+         shim: undefined,
+         dependencies: undefined,
+         map: undefined,
+         removeJSExtensions: undefined,
+         transpile: undefined,
+         minify: undefined,
+         sourceURLBase: undefined,
+         alwaysIncludeFormat: undefined
+      };
+      build.compileDir(inputDir, options)
+         .then(function() {
+            return asp(fs.readFile)(outputFile, 'utf8');
+         })
+         .then(function(source) {
+            //console.log(source);
+            assert(source.match(/\s*"format global";\s*/));
+         })
+         .then(done, done);
+   });
+});

--- a/test/fixtures/compile/format/cjs/entry.js
+++ b/test/fixtures/compile/format/cjs/entry.js
@@ -1,0 +1,3 @@
+var newbury = {};
+newbury.visit = true;
+module.exports = newbury;

--- a/test/fixtures/compile/format/cjs/jspm_packages/ignoreme2.js
+++ b/test/fixtures/compile/format/cjs/jspm_packages/ignoreme2.js
@@ -1,0 +1,1 @@
+window.seeme = false;

--- a/test/fixtures/compile/format/cjs/node_modules/ignoreme.js
+++ b/test/fixtures/compile/format/cjs/node_modules/ignoreme.js
@@ -1,0 +1,2 @@
+var seeme = false;
+module.exports = seeme;

--- a/test/fixtures/compile/glob/cjs/entry.js
+++ b/test/fixtures/compile/glob/cjs/entry.js
@@ -1,0 +1,3 @@
+var newbury = {};
+newbury.visit = true;
+module.exports = newbury;

--- a/test/fixtures/compile/glob/cjs/jspm_packages/ignoreme2.js
+++ b/test/fixtures/compile/glob/cjs/jspm_packages/ignoreme2.js
@@ -1,0 +1,1 @@
+window.seeme = false;

--- a/test/fixtures/compile/glob/cjs/node_modules/ignoreme.js
+++ b/test/fixtures/compile/glob/cjs/node_modules/ignoreme.js
@@ -1,0 +1,2 @@
+var seeme = false;
+module.exports = seeme;

--- a/test/fixtures/compile/shim/cjs/entry.js
+++ b/test/fixtures/compile/shim/cjs/entry.js
@@ -1,0 +1,3 @@
+var newcastle = {};
+newcastle.visit = true;
+module.exports = newcastle;

--- a/test/fixtures/compile/shim/es6/entry.css
+++ b/test/fixtures/compile/shim/es6/entry.css
@@ -1,0 +1,3 @@
+.selected {
+   color: red;
+}

--- a/test/fixtures/compile/shim/es6/entry.es6
+++ b/test/fixtures/compile/shim/es6/entry.es6
@@ -1,0 +1,3 @@
+var manchester = {};
+manchester.faraway = true;
+export default manchester;

--- a/test/fixtures/compile/shim/global/entry.js
+++ b/test/fixtures/compile/shim/global/entry.js
@@ -1,0 +1,2 @@
+var birmingham = birminham || {};
+birmingham.visit = false;


### PR DESCRIPTION
... shim is present

So according to the spec, shims are not limited to globals, but in fact specifying a shim for a commonjs module sets the format to global in the meta, which causes 'require is not defined' errors. This change only sets the format to global if the shim has exports defined.

There are also a couple of other potential issues which I have added tests for but not fixed as I would like to know what you think first:

1) When compiling a directory it globs every single js file in the directory, normally this is not important but when doing ```jspm link``` it means that it is traversing the whole of node_modules and jspm_packages which is rather slow. If the module has directories.lib set then it avoids the problem but that is not always possible.

2) Because of the globbing, it is not possible to shim files unless they have a '.js' extension. I think that the shimmed filenames (ie the keys of 'shim') should be included in the glob. In my case I would like to shim a typescript file (.ts) with some css.