### PR TITLE
fix(dep): semver security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "request": "^2.53.0",
     "rimraf": "^2.3.2",
     "rsvp": "^3.0.17",
-    "semver": "^4.3.1",
+    "semver": "^4.3.2",
     "systemjs": "^0.16.7",
     "systemjs-builder": "^0.10.4",
     "traceur": "0.0.87",


### PR DESCRIPTION
Enforce semver to a version 4.3.2 or greater for security reason.
see [semver Regular Expression Denial of Service](https://nodesecurity.io/advisories/semver_redos)