### PR TITLE
chore(coverage): add cover info through istanbul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 testlibs/jspm_packages
 testlibs/build.js*
 test/outputs
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,12 @@ node_js:
   - '0.11'
   - '0.12'
   - 'iojs'
+env:
+  global:
+    - COVERAGE=false
+matrix:
+  include:
+    - node_js: "0.12"
+      env: COVERAGE=true
+after_success:
+  - "[ $COVERAGE == false ] || npm run istanbul -- --report text-summary"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "registry": "npm",
   "devDependencies": {
+    "istanbul": "^0.3.13",
     "jshint": "~2.6.1",
     "mocha": "~1.17.1"
   },
@@ -39,6 +40,8 @@
   },
   "scripts": {
     "test": "npm run jshint && npm run mocha",
+    "istanbul": "istanbul cover ./node_modules/.bin/_mocha -i='lib/**/*.js'",
+    "coverage": "npm run istanbul -- --report html",
     "mocha": "mocha",
     "jshint": "jshint api.js cli.js jspm.js lib test"
   },


### PR DESCRIPTION
Run `npm run coverage` will run the coverage with HTML output.

TODO: Use the [travis hook](http://docs.travis-ci.com/user/code-climate/#JavaScript) to publish the coverage on Code Climate. (tips https://coderwall.com/p/5mtq6q/encrypt-your-code-climate-repo-token-for-public-repositories-on-travis-ci)