### PR TITLE
Read existing ranges for `jspm update x`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -172,6 +172,7 @@ process.on('uncaughtException', function(err) {
     case 'install':
       options = readOptions(args, ['--force', '--override', '--link', '--yes', '--lock', '--latest', '--unlink', '--quick', '--dev']);
       options.inject = inject;
+      options.doUpdate = doUpdate;
 
       args = options.args;
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -93,8 +93,14 @@ exports.install = function(targets, options) {
     if (options.link || options.quick)
       options.lock = true;
 
+    var defaultTargets = options.dev ? config.pjson.devDependencies : config.pjson.dependencies;
     if (targets === true)
-      targets = options.dev ? config.pjson.devDependencies : config.pjson.dependencies;
+      targets = defaultTargets;
+    else if (options.doUpdate)
+      Object.keys(defaultTargets).forEach(function(module) {
+        if (module in targets)
+          targets[module] = defaultTargets[module];
+      });
 
     targets = pkg.processDeps(targets, globalConfig.config.registry);
 


### PR DESCRIPTION
Refs #640 

##### Before:

```
jspm install jquery@1.7 # installs 1.7.2
jspm update jquery      # installs 2.1.3
```

##### After:

```
jspm install jquery@1.7 # installs 1.7.2
jspm update jquery      # installs 1.11.2 (which matches 1.7 in packages.json)
jspm install jquery     # installs 2.1.3
```