### PR TITLE
Allow shim deps to apply for any module format

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -417,7 +417,13 @@ exports.compileDir = function(dir, options) {
             if (typeof curShim.deps === 'string')
               curShim.deps = [curShim.deps];
 
-            var depStr = '"format global";' + nl;
+            var depStr = '';
+
+            var isGlobal = options.format === 'global' || curShim.exports;
+
+            if (isGlobal)
+              depStr += '"format global";' + nl;
+
             if (curShim.deps)
               for (var i = 0; i < curShim.deps.length; i++)
                 depStr += '"deps ' + curShim.deps[i] + '";' + nl;
@@ -428,7 +434,7 @@ exports.compileDir = function(dir, options) {
             changed = true;
             source = depStr + source;
 
-            return true;
+            return isGlobal;
           })
 
           // add any format hint if provided


### PR DESCRIPTION
Only when `format: global` or exports is set do we treat as a global.

Note that this requires processing all overrides in the registry to ensure that `format: global` or `exports` are set where global processing is implied.