### PR TITLE
Support "stable" prereleases

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -162,10 +162,10 @@ function getVersionMatch(pkgVersion, versions) {
     var semverMatch = version.match(semver.semverRegEx);
     var valid = semverMatch && semverMatch[1] && semverMatch[2] && semverMatch[3];
     var pre = valid && semverMatch[4];
+    var stable = versions[version].stable;
 
-    // ignore unstable
-    // (stable is semver, without prerelease)
-    if (!valid || pre) {
+    // ignore non-semver or prerelease, unless explictly marked as stable
+    if (!stable && (!valid || pre)) {
       latestPre = latestPre || pre && version;
       continue;
     }

--- a/test/package.js
+++ b/test/package.js
@@ -12,6 +12,16 @@ suite('getVersionMatch', function() {
       };
       assert.equal('2.0.0', package.getVersionMatch('', versions).version);
     });
+    test('Resolves to prereleases if explictly marked stable', function() {
+      var versions = {
+        'master': {},
+        '2.0.0': {},
+        '2.0.1-alpha.1': {stable: true},
+        '2.0.1-alpha.2': {},
+        'experimental': {}
+      };
+      assert.equal('2.0.1-alpha.1', package.getVersionMatch('', versions).version);
+    });
     test('Favours prerelease over master', function() {
       var versions = {
         'master': {},


### PR DESCRIPTION
@guybedford let me know if this fits your idea of how prereleases should interact with the `stable` flag