### PR TITLE
Disallow version in `jspm update x@version`

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -96,9 +96,9 @@ exports.install = function(targets, options) {
     var defaultTargets = options.dev ? config.pjson.devDependencies : config.pjson.dependencies;
     if (targets === true)
       targets = defaultTargets;
-    else if (options.doUpdate)
-      Object.keys(defaultTargets).forEach(function(module) {
-        if (module in targets)
+    else if (targets && options.doUpdate)
+      Object.keys(targets).forEach(function(module) {
+        if (!targets[module])
           targets[module] = defaultTargets[module];
       });
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -106,7 +106,7 @@ exports.install = function(targets, options) {
       Object.keys(targets).forEach(function(module) {
         var target = targets[module];
         var configured = defaultTargets[module];
-        if (!configured || target && target !== configured.version) {
+        if (!configured || target) {
           var moduleExpr = target ? module + '@' + target : module;
           error = configured ? 'update-with-version' : 'implicit-install';
           ui.log('warn', 'Did you mean `jspm install ' + moduleExpr + '`?');

--- a/lib/install.js
+++ b/lib/install.js
@@ -47,6 +47,11 @@ var installing = {
   depMap: {}
 };
 
+var errorMessages = {
+  'implicit-install': 'Update does not support implicit installs.',
+  'update-with-version': 'Update does not support explicit version ranges.'
+};
+
 // NB remove assertions for release
 // function assert(statement, name) {
 //  if (!statement)
@@ -85,6 +90,7 @@ exports.install = function(targets, options) {
 
   return config.load()
   .then(function() {
+    var error;
     installed = installed || config.loader;
 
     if (options.force)
@@ -98,9 +104,20 @@ exports.install = function(targets, options) {
       targets = defaultTargets;
     else if (targets && options.doUpdate)
       Object.keys(targets).forEach(function(module) {
-        if (!targets[module])
-          targets[module] = defaultTargets[module];
+        var target = targets[module];
+        var configured = defaultTargets[module];
+        if (!configured || target && target !== configured.version) {
+          var moduleExpr = target ? module + '@' + target : module;
+          error = configured ? 'update-with-version' : 'implicit-install';
+          ui.log('warn', 'Did you mean `jspm install ' + moduleExpr + '`?');
+        }
+        targets[module] = configured || '';
       });
+
+    if (error) {
+      ui.log('err', errorMessages[error]);
+      process.exit(1);
+    }
 
     targets = pkg.processDeps(targets, globalConfig.config.defaultRegistry);
 


### PR DESCRIPTION
Refines #667 

Alternately, you may not want to support explicit versions in `update`