### PR TITLE
Changes HOME on Windows to %LOCALAPPDATA%.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,7 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-exports.HOME = process.env.HOME || process.env.USERPROFILE || process.env.HOMEPATH;
+exports.HOME = process.env.HOME || process.env.LOCALAPPDATA || process.env.HOMEPATH;
 
 var ui = require('./ui');
 var fs = require('graceful-fs');


### PR DESCRIPTION
Fixes https://github.com/jspm/jspm-cli/issues/677 but without solving the migration problem.

A more correct cross-platform solution would be to have config.js expose multiple environment variables for correct paths depending on content.

The `.` prefix on Windows doesn't serve any purpose and can be removed, but this would require a larger refactor to have OS specific directory names.

A quick search (https://github.com/jspm/jspm-cli/search?utf8=%E2%9C%93&q=config+home&type=Code) suggests that the only thing HOME is used for is the .jspm folder so perhaps config.js could instead expose the JSPM cache/settings folder (name TBD) which could then be named more appropriately on Windows vs *nix.