### PR TITLE
Add globally configured transpiler default

### DIFF
--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -26,6 +26,7 @@ var alphabetize = require('../common').alphabetize;
 var stringify = require('../common').stringify;
 var ui = require('../ui');
 var extractObj = require('./utils').extractObj;
+var globalConfig = require('../global-config');
 
 /*
  * Loader Configuration Class
@@ -100,7 +101,7 @@ Config.prototype.read = function(prompts, sync) {
   self.baseURL = cfg.baseURL;
 
   // NB deprecate cfg.parser with 0.11.0
-  self.transpiler = cfg.transpiler || cfg.parser || 'traceur';
+  self.transpiler = cfg.transpiler || cfg.parser || globalConfig.config.defaultTranspiler;
   // NB deprecate babel rename with 0.13
   if (self.transpiler === '6to5')
     self.transpiler = 'babel';
@@ -188,6 +189,7 @@ Config.prototype.read = function(prompts, sync) {
     if (transpiler !== 'babel')
       transpiler = 'traceur';
     self.transpiler = transpiler;
+    globalConfig.config.defaultTranspiler = transpiler;
   });
 };
 

--- a/lib/global-config.js
+++ b/lib/global-config.js
@@ -90,6 +90,7 @@ if (!exports.config.registries && exports.config.endpoints)
  * Populate default registry configuration
  */
 dprepend(exports.config, {
+  defaultTranspiler: 'traceur',
   defaultRegistry: 'jspm',
   registries: {
     github: {

--- a/lib/install.js
+++ b/lib/install.js
@@ -883,7 +883,7 @@ function clean() {
       return asp(rimraf)(dir)
       .then(function() {
         var filename = dir + '.js';
-        return new Promise(function(resolve, reject) {
+        return new Promise(function(resolve) {
           fs.exists(filename, resolve);
         }).then(function(exists) {
           if (exists) return asp(fs.unlink)(filename);
@@ -918,7 +918,7 @@ function readDirWithDepth(dir, depthCheck) {
     return Promise.all(files.map(function(file) {
       var filepath = path.resolve(dir, file);
       /* `dir` is always absolute path, so equality implies isSymbolicLink above */
-      var notSymlink = dir != file;
+      var notSymlink = dir !== file;
       if (notSymlink && depthCheck(filepath)) {
         return readDirWithDepth(filepath, depthCheck).then(pushMany);
       } else {


### PR DESCRIPTION
Covers #691, defaults to Traceur to begin with but the default will switch depending on the last entered choice made by the user.

As mentioned in gitter `npm test` failed due to some jshint errors, I've fixed those up in the most basic way but not sure if that may cause regressions.