### PR TITLE
Support convention of "latest" version

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -128,7 +128,8 @@ exports.lookup = function(pkg) {
     lookups[pkg.package] = lookup.versions;
 
     return function(version) {
-      var lookupObj = getVersionMatch(version, lookup.versions);
+      var options = {latestVersion: lookup.latest};
+      var lookupObj = getVersionMatch(version, lookup.versions, options);
       if (!lookupObj)
         return;
 

--- a/lib/package.js
+++ b/lib/package.js
@@ -128,8 +128,7 @@ exports.lookup = function(pkg) {
     lookups[pkg.package] = lookup.versions;
 
     return function(version) {
-      var options = {latestVersion: lookup.latest};
-      var lookupObj = getVersionMatch(version, lookup.versions, options);
+      var lookupObj = getVersionMatch(version, lookup.versions, {latestVersion: lookup.latest});
       if (!lookupObj)
         return;
 
@@ -175,12 +174,15 @@ function getVersionMatch(pkgVersion, versions, options) {
     var latest = options && options.latestVersion && versions[options.latestVersion];
     if (latest && latest.stable !== false) return latest;
     stableVersions.sort(compareDesc);
-    if (stableVersions[0]) return versions[stableVersions[0]];
+    if (stableVersions[0])
+      return versions[stableVersions[0]];
 
     if (latest) return latest;
     unstableVersions.sort(compareDesc);
-    if (unstableVersions[0]) return versions[unstableVersions[0]];
-  } else {
+    if (unstableVersions[0])
+      return versions[unstableVersions[0]];
+  }
+  else {
     var i, ver;
     stableVersions.sort(compareDesc);
     // find highest stable match in tags

--- a/lib/package.js
+++ b/lib/package.js
@@ -187,13 +187,13 @@ function getVersionMatch(pkgVersion, versions, options) {
     for (i = 0; i < stableVersions.length; i++) {
       ver = stableVersions[i];
       if (semver.match(pkgVersion, ver))
-        return ver;
+        return versions[ver];
     }
     unstableVersions.sort(compareDesc);
     for (i = 0; i < unstableVersions.length; i++) {
       ver = unstableVersions[i];
       if (semver.match(pkgVersion, ver))
-        return ver;
+        return versions[ver];
     }
     // finally check for an exact tag match
     if (versions[pkgVersion])

--- a/lib/package.js
+++ b/lib/package.js
@@ -140,66 +140,64 @@ exports.lookup = function(pkg) {
 };
 
 exports.getVersionMatch = getVersionMatch;
-function getVersionMatch(pkgVersion, versions) {
+function getVersionMatch(pkgVersion, versions, options) {
   // unescape pkgVersion for comparison
   if (pkgVersion)
     pkgVersion = decodeURIComponent(pkgVersion);
 
-  var latestPre;
-  var versionList = [];
-  var exactVersions = [];
+  var version;
+  var stableVersions = [];
+  var unstableVersions = [];
 
   Object.keys(versions).forEach(function(v) {
-    versions[v].version = v;
-    if (versions[v].stable === false || versions[v].exactOnly)
-      exactVersions.push(v);
-    else
-      versionList.push(v);
-  });
-
-  exactVersions.sort(semver.compare).reverse();
-  versionList.sort(semver.compare).reverse();
-
-  // find highest stable match in tags
-  for (var i = 0; i < versionList.length; i++) {
-    var version = versionList[i];
-    var semverMatch = version.match(semver.semverRegEx);
+    version = versions[v];
+    var stable = version.stable;
+    var semverMatch = v.match(semver.semverRegEx);
     var valid = semverMatch && semverMatch[1] && semverMatch[2] && semverMatch[3];
     var pre = valid && semverMatch[4];
-    var stable = versions[version].stable;
+
+    // store a reverse lookup
+    version.version = v;
 
     // ignore non-semver or prerelease, unless explictly marked as stable
-    if (!stable && (!valid || pre)) {
-      latestPre = latestPre || pre && version;
-      continue;
-    }
+    if (stable === false || !valid || (stable !== true && pre))
+      unstableVersions.push(v);
+    else
+      stableVersions.push(v);
+  });
 
-    if (!pkgVersion || semver.match(pkgVersion, version))
-      return versions[version];
+  function compareDesc(a, b) {
+    return semver.compare(b, a);
   }
 
-  // if we asked for latest, and nothing stable found, use master or otherwise top
   if (!pkgVersion) {
-    if (latestPre)
-      return versions[latestPre];
-    if (versions.master)
-      return versions.master;
-    return versions[versionList[0] || exactVersions[0]];
-  }
+    var latest = options && options.latestVersion && versions[options.latestVersion];
+    if (latest && latest.stable !== false) return latest;
+    stableVersions.sort(compareDesc);
+    if (stableVersions[0]) return versions[stableVersions[0]];
 
-  // next try an unstable version range match in tags then branches
-  for (var j = 0; j < versionList.length; j++) {
-    if (semver.match(pkgVersion, versionList[j]))
-      return versions[versionList[j]];
+    if (latest) return latest;
+    unstableVersions.sort(compareDesc);
+    if (unstableVersions[0]) return versions[unstableVersions[0]];
+  } else {
+    var i, ver;
+    stableVersions.sort(compareDesc);
+    // find highest stable match in tags
+    for (i = 0; i < stableVersions.length; i++) {
+      ver = stableVersions[i];
+      if (semver.match(pkgVersion, ver))
+        return ver;
+    }
+    unstableVersions.sort(compareDesc);
+    for (i = 0; i < unstableVersions.length; i++) {
+      ver = unstableVersions[i];
+      if (semver.match(pkgVersion, ver))
+        return ver;
+    }
+    // finally check for an exact tag match
+    if (versions[pkgVersion])
+      return versions[pkgVersion];
   }
-  for (var k = 0; k < exactVersions.length; k++) {
-    if (semver.match(pkgVersion, exactVersions[k]))
-      return versions[exactVersions[k]];
-  }
-
-  // finally check for an exact tag match
-  if (pkgVersion && versions[pkgVersion])
-    return versions[pkgVersion];
 }
 
 // returns {hash} or {notfound} or {linked}

--- a/lib/package.js
+++ b/lib/package.js
@@ -148,6 +148,8 @@ function getVersionMatch(pkgVersion, versions, options) {
   var version;
   var stableVersions = [];
   var unstableVersions = [];
+  var exactStableVersions = [];
+  var exactUnstableVersions = [];
 
   Object.keys(versions).forEach(function(v) {
     version = versions[v];
@@ -160,7 +162,15 @@ function getVersionMatch(pkgVersion, versions, options) {
     version.version = v;
 
     // ignore non-semver or prerelease, unless explictly marked as stable
-    if (stable === false || !valid || (stable !== true && pre))
+    if (!valid) {
+      // unstable unless explicitly stable
+      if (stable)
+        exactStableVersions.push(v);
+      else
+        exactUnstableVersions.push(v);
+    }
+    // stable unless explicitly unstable or indetermate and a prerelease
+    else if (stable === false || (stable !== true && pre))
       unstableVersions.push(v);
     else
       stableVersions.push(v);
@@ -172,15 +182,27 @@ function getVersionMatch(pkgVersion, versions, options) {
 
   if (!pkgVersion) {
     var latest = options && options.latestVersion && versions[options.latestVersion];
-    if (latest && latest.stable !== false) return latest;
+    if (latest)
+      return latest;
     stableVersions.sort(compareDesc);
+
     if (stableVersions[0])
       return versions[stableVersions[0]];
 
-    if (latest) return latest;
     unstableVersions.sort(compareDesc);
     if (unstableVersions[0])
       return versions[unstableVersions[0]];
+
+    exactStableVersions.sort();
+    if (exactStableVersions[0])
+      return versions[exactStableVersions[0]];
+
+    if (versions.master)
+      return versions.master;
+
+    exactUnstableVersions.sort();
+    if (exactUnstableVersions[0])
+      return versions[exactUnstableVersions[0]];
   }
   else {
     var i, ver;

--- a/test/package.js
+++ b/test/package.js
@@ -42,6 +42,28 @@ suite('getVersionMatch', function() {
       var opts = {latestVersion: 'master'};
       assert.equal('master', package.getVersionMatch('', versions, opts).version);
     });
+    test('Satisfies range', function() {
+      var versions = {
+        'master': {},
+        '2.0.0': {},
+        '2.0.1-alpha.1': {},
+        '2.0.1-alpha.2': {},
+        'experimental': {}
+      };
+      var opts = {latestVersion: 'master'};
+      assert.equal('2.0.1-alpha.2', package.getVersionMatch('^2.0.1-0', versions, opts).version);
+    });
+    test('Satisfies range', function() {
+      var versions = {
+        'master': {},
+        '2.0.0': {},
+        '2.0.1-alpha.1': {},
+        '2.0.1-alpha.2': {},
+        'experimental': {}
+      };
+      var opts = {latestVersion: 'master'};
+      assert.equal(undefined, package.getVersionMatch('^2.0.1', versions, opts));
+    });
   });
 });
 

--- a/test/package.js
+++ b/test/package.js
@@ -92,6 +92,16 @@ suite('getVersionMatch', function() {
       var opts = {latestVersion: 'master'};
       assert.equal(undefined, package.getVersionMatch('^2.0.1', versions, opts));
     });
+    test('Favours latestVersion always if no range provided', function() {
+      var versions = {
+        'master': {},
+        '2.0.0': {},
+        '2.0.1-alpha.1': {},
+        'schwarzwälder-kirschtorte': {stable: false}
+      };
+      var opts = {latestVersion: 'schwarzwälder-kirschtorte'};
+      assert.equal('schwarzwälder-kirschtorte', package.getVersionMatch('', versions, opts).version);
+    });
   });
 });
 

--- a/test/package.js
+++ b/test/package.js
@@ -31,18 +31,46 @@ suite('getVersionMatch', function() {
       };
       assert.equal('2.0.1-alpha.2', package.getVersionMatch('', versions).version);
     });
+    test('Favours prerelease over tags', function() {
+      var versions = {
+        '2.0.1-alpha.1': {},
+        'super-cool': {stable: true},
+        'sketchy': {}
+      };
+      assert.equal('2.0.1-alpha.1', package.getVersionMatch('', versions).version);
+    });
     test('Favours master over regular tags', function() {
       var versions = {
         'master': {},
-        '2.0.0': {},
-        '2.0.1-alpha.1': {},
-        '2.0.1-alpha.2': {},
         'experimental': {}
       };
-      var opts = {latestVersion: 'master'};
-      assert.equal('master', package.getVersionMatch('', versions, opts).version);
+      assert.equal('master', package.getVersionMatch('', versions).version);
     });
-    test('Satisfies range', function() {
+    test('Favours stable tags over master', function() {
+      var versions = {
+        'master': {},
+        'experimental': {stable: true},
+        'alpha': {}
+      };
+      assert.equal('experimental', package.getVersionMatch('', versions).version);
+    });
+    test('Favours stable tags alphabetically', function() {
+      var versions = {
+        'a': {},
+        'c': {stable: true},
+        'b': {stable: true}
+      };
+      assert.equal('b', package.getVersionMatch('', versions).version);
+    });
+    test('Favours unstable tags alphabetically', function() {
+      var versions = {
+        'b': {},
+        'a': {},
+        'c': {}
+      };
+      assert.equal('a', package.getVersionMatch('', versions).version);
+    });
+    test('Satisfies range A', function() {
       var versions = {
         'master': {},
         '2.0.0': {},
@@ -53,7 +81,7 @@ suite('getVersionMatch', function() {
       var opts = {latestVersion: 'master'};
       assert.equal('2.0.1-alpha.2', package.getVersionMatch('^2.0.1-0', versions, opts).version);
     });
-    test('Satisfies range', function() {
+    test('Satisfies range B', function() {
       var versions = {
         'master': {},
         '2.0.0': {},

--- a/test/package.js
+++ b/test/package.js
@@ -34,9 +34,13 @@ suite('getVersionMatch', function() {
     test('Favours master over regular tags', function() {
       var versions = {
         'master': {},
+        '2.0.0': {},
+        '2.0.1-alpha.1': {},
+        '2.0.1-alpha.2': {},
         'experimental': {}
       };
-      assert.equal('master', package.getVersionMatch('', versions).version);
+      var opts = {latestVersion: 'master'};
+      assert.equal('master', package.getVersionMatch('', versions, opts).version);
     });
   });
 });


### PR DESCRIPTION
Refs jspm/npm#34

@guybedford so github and npm endpoints would be updated to return things like `{versions: [...], latest: 'master'}`

Passing in `options`, rather than `latestVersion` directly, to anticipate `--edge` option.