### PR TITLE
Fix #783, added --inline-source-maps in in bundle and bundle-sfx command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -366,7 +366,7 @@ process.on('uncaughtException', function(err) {
       options.mangle = !options['no-mangle'];
       
       if (options['inline-source-maps']){
-        options.sourceMapContents = true;
+        options.sourceMaps = "inline";
       }
 
       var bArgs = options.args.splice(1);

--- a/cli.js
+++ b/cli.js
@@ -366,7 +366,7 @@ process.on('uncaughtException', function(err) {
       options.mangle = !options['no-mangle'];
       
       if (options['inline-source-maps']){
-        options.sourceMapContents = 'inline';
+        options.sourceMapContents = true;
       }
 
       var bArgs = options.args.splice(1);

--- a/cli.js
+++ b/cli.js
@@ -358,12 +358,17 @@ process.on('uncaughtException', function(err) {
       var sfxBundle = true;
 
     case 'bundle':
-      options = readOptions(args, ['--inject', '--yes', '--skip-source-maps', '--minify',  '--no-mangle', '--hires-source-maps', '--no-runtime']);
+      options = readOptions(args, ['--inject', '--yes', '--skip-source-maps', '--minify',  '--no-mangle', '--hires-source-maps', '--no-runtime', '--inline-source-maps']);
       if (options.yes)
         ui.useDefaults();
       options.sourceMaps = !options['skip-source-maps'];
       options.lowResSourceMaps = !options['hires-source-maps'];
       options.mangle = !options['no-mangle'];
+      
+      if (options['inline-source-maps']){
+        options.sourceMapContents = 'inline';
+      }
+
       var bArgs = options.args.splice(1);
 
       if (bArgs.length === 0) {


### PR DESCRIPTION
Shoudl fix #783, I just made the option `--inline-source-maps` instead of `--inline-source-map`, mind the trailing *s*.

@crisptrutski , please give it a look.