### PR TITLE
feat(unbundle): expose unbundle in the public api

### DIFF
--- a/api.js
+++ b/api.js
@@ -147,6 +147,13 @@ API.bundle = function(expression, fileName, options) {
 };
 
 /*
+ * Returns a promise for unbundling
+ */
+API.unbundle = function() {
+  return bundle.unbundle();
+};
+
+/*
  * Remove the bundle configuration.
  * This will allow you to move back to separate file mode
  * returns a promise


### PR DESCRIPTION
It may be desirable as part of an automated task (in e.g. gulp) to
be able to unbundle programmatically, just like you can currently
bundle.