### PR TITLE
Docs/GitHub rate limits

### DIFF
--- a/docs/installing-packages.md
+++ b/docs/installing-packages.md
@@ -60,7 +60,7 @@ This can equally be written:
 
 Any version tag or branch can be installed this way for GitHub and npm. Commit-based installs are not supported for the GitHub registry currently.
 
-Install a version range with - 
+Install a version range with -
 
 [Semver compatibility range](https://github.com/npm/node-semver#caret-ranges-123-025-004):
 
@@ -155,7 +155,7 @@ To inspect all installed dependencies use `jspm inspect`:
                     npm:inherits 2.0.1
                      npm:process 0.10.0
                         npm:util 0.10.3
-     
+
   To inspect individual package constraints, use jspm inspect registry:name.
 ```
 
@@ -165,9 +165,9 @@ To see the install constraints for a given dependency use `jspm inspect registry
 
 ```
   jspm inspect npm:util
-     
+
   Installed versions of npm:util
-     
+
     github:jspm/nodelibs-util@0.1.0
       util 0.10.3 (^0.10.3)
 ```
@@ -196,7 +196,7 @@ To uninstall a package:
   jspm uninstall jquery
        Clearing configuration for github:components/jquery@2.1.3
        Removing package files for github:components/jquery@2.1.3
-  
+
   ok   Uninstall complete.
 ```
 
@@ -223,3 +223,11 @@ In this way, these resolution solutions are all handled greedily on a case-by-ca
 If the install causes an existing dependency to break because of new resolutions, you can revert and install with `jspm install --lock newpackage`. This will then not alter any of the existing resolutions in the tree at all, only performing deduping in the new tree.
 
 For further interest, the code for the resolution algorithm can be found in https://github.com/jspm/jspm-cli/blob/master/lib/install.js#L71.
+
+### Github Rate Limiting
+
+Github rate limits by IP unless an auth token is provided. On hosted CI and PaaS services such as Circle, Travis and Heroku where you share IPs with other users you will often see a `GitHub rate limit reached.` error message.
+
+Most CI and PaaS services have the ability to do add environment variables from their web panels. If you set a `JSPM_GITHUB_AUTH_TOKEN` variable in your environment, jspm will effectively call `jspm config registries.github.auth $JSPM_GITHUB_AUTH_TOKEN` on your behalf.
+
+> The `JSPM_GITHUB_AUTH_TOKEN` is an unencrypted Base64 encoding of the GitHub username and *password* or *access token* (separated by a `:`, e.g. `username:token`). A generated `JSPM_GITHUB_AUTH_TOKEN` can be found in `~/.jspm/config` after you have [configured private Github](registries.md#private-github).

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -124,26 +124,6 @@ For npm, you may wish to automate the loading of config from npmrc. This can be 
 
 Which will just respond with defaults to all questions asked during registry install.
 
-#### Travis CI
-
-To configure registries through TravisCI, use the [Travis CLI tool](https://github.com/travis-ci/travis.rb#installation) to encrypt the **[JSPM_GITHUB_AUTH_TOKEN](#auto-configuring-registries)** from the `jspm registry export`.
-
-```
-travis encrypt 'JSPM_GITHUB_AUTH_TOKEN=[JSPM_GITHUB_AUTH_TOKEN]'
-```
-
-Then include it in Travis.yml:
-
-```yml
-env:
-  global:
-  - secure: [ENCRYPTED_STRING]
-
-before_install:
-- npm install -g jspm
-- jspm config registries.github.auth $JSPM_GITHUB_AUTH_TOKEN
-```
-
 ### Creating a Private jspm Registry
 
 You may wish to run your own version of the jspm registry instead of using the publicly maintained default. Running your own registry is particularly useful if you want to create short names to private packages and test lots of overrides.

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -26,12 +26,6 @@ Would you like to test these credentials? [yes]:
 
 This will enable private repo installs.
 
-#### Github Rate Limiting
-
-Github rate limits by IP unless an auth token is provided. On hosted services such as Circle, Travis or Heroku where you share IPs with other users also using Github you will likely hit these limits. Setting a `JSPM_GITHUB_AUTH_TOKEN` variable in your environment is enough to tell jspm to use it. Most services have the ability to do this from their web panels.
-
-The `JSPM_GITHUB_AUTH_TOKEN` is an unencrypted Base64 encoding of the GitHub username and *password* or *access token* (separated by a `:`, e.g. `username:token`). The access token needs the `public_repo` scope. A generated `JSPM_GITHUB_AUTH_TOKEN` can be found in `~/.jspm/config` after you have configured private Github.
-
 #### Private npm
 
 Similarly for npm, we can authenticate and set a custom registry path through the configuration:
@@ -113,6 +107,9 @@ jspm config registries.github.auth JSPM_GITHUB_AUTH_TOKEN
 jspm config registries.github.maxRepoSize 100
 jspm config registries.github.handler jspm-github
 ```
+
+> The JSPM_GITHUB_AUTH_TOKEN above is an unencrypted Base64 encoding of the GitHub username and password or access token (separated by a :, e.g. username:token). The access token needs the public_repo scope.
+
 
 These commands can then be run to easily regenerate the registry configuration.
 

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -16,15 +16,21 @@ To support private GitHub, simply authenticate with your private GitHub account:
 ```
 
 ```
-Would you like to set up your GitHub credentials? [yes]: 
+Would you like to set up your GitHub credentials? [yes]:
      If using two-factor authentication or to avoid using your password you can generate an access token at https://github.com/settings/applications.
 
 Enter your GitHub username: username
-Enter your GitHub password or access token: 
-Would you like to test these credentials? [yes]: 
+Enter your GitHub password or access token:
+Would you like to test these credentials? [yes]:
 ```
 
 This will enable private repo installs.
+
+#### Github Rate Limiting
+
+Github rate limits by IP unless an auth token is provided. On hosted services such as Circle, Travis or Heroku where you share IPs with other users also using Github you will likely hit these limits. Setting a `JSPM_GITHUB_AUTH_TOKEN` variable in your environment is enough to tell jspm to use it. Most services have the ability to do this from their web panels.
+
+The `JSPM_GITHUB_AUTH_TOKEN` is an unencrypted Base64 encoding of the GitHub username and *password* or *access token* (separated by a `:`, e.g. `username:token`). The access token needs the `public_repo` scope. A generated `JSPM_GITHUB_AUTH_TOKEN` can be found in `~/.jspm/config` after you have configured private Github.
 
 #### Private npm
 
@@ -38,7 +44,7 @@ When available, the npm registry endpoint will automatically pull authentication
 and will not need to store this separately.
 
 ```
-npm registry [https://registry.npmjs.org]: 
+npm registry [https://registry.npmjs.org]:
 Currently reading credentials from npmrc, configure custom authentication? [no]:
 ```
 
@@ -50,7 +56,7 @@ You may wish to create your own custom registries, such as a custom private `npm
 
 > Note that it is not advisable to create an registry with a different name to `npm` or `github` if it is a mirror, as the goal is for registry names to be canonical and universal. **Only use this option when your custom registry doesn't duplicate public packages on npm or GitHub.**
 
-#### Separate private npm
+#### Separate Private npm
 
 This can be setup with:
 
@@ -64,15 +70,15 @@ We now have an `npm` registry based on a custom registry and authentication whic
   jspm install myregistry:package
 ```
 
-#### GitHub enterprise support
+#### GitHub Enterprise Support
 
 It is possible to create a GitHub enterprise support with:
 
 ```
   jspm registry create mycompany jspm-github
-Are you setting up a GitHub Enterprise endpoint? [yes]: 
+Are you setting up a GitHub Enterprise endpoint? [yes]:
 Enter the hostname of your GitHub Enterprise server: mycompany.com
-Would you like to set up your GitHub credentials? [yes]: 
+Would you like to set up your GitHub credentials? [yes]:
 ```
 
 Note that GitHub enterprise support has not been comprehensively tested, as we've had to rely on feedback and PRs from GitHub enterprise users. If there are any issues at all please post an issue and we'll work to fix these.
@@ -107,7 +113,6 @@ jspm config registries.github.auth JSPM_GITHUB_AUTH_TOKEN
 jspm config registries.github.maxRepoSize 100
 jspm config registries.github.handler jspm-github
 ```
-> The JSPM_GITHUB_AUTH_TOKEN above is an unencrypted Base64 encoding of the GitHub username and *password* or *access token* (separated by a `:`, e.g. `username:token`). The access token needs the `public_repo` scope.
 
 These commands can then be run to easily regenerate the registry configuration.
 
@@ -139,7 +144,7 @@ before_install:
 - jspm config registries.github.auth $JSPM_GITHUB_AUTH_TOKEN
 ```
 
-### Creating a private jspm Registry
+### Creating a Private jspm Registry
 
 You may wish to run your own version of the jspm registry instead of using the publicly maintained default. Running your own registry is particularly useful if you want to create short names to private packages and test lots of overrides.
 


### PR DESCRIPTION
Adds docs for Github auth and rate limiting and removes the Travis CI configuration section that it supersedes. I moved the `JSPM_GITHUB_AUTH_TOKEN` in here too since it makes more sense that way.

Also title-cased some of the headings and my editor trimmed trailing whitespace of its own accord.