### PR TITLE
Set meta information at the end so that entries get normalized properly

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -143,9 +143,18 @@ exports.getRedirectContents = function(format, main) {
     throw 'Unknown module format ' + format + '.';
 };
 
-exports.stringify = function (subject) {
+exports.stringify = function (subject, contentOnly) {
   // replace the LF used by `JSON.stringify` with the preferred new line
-  return JSON.stringify(subject, null, 2).replace(/\n/g, EOL);
+  var str = JSON.stringify(subject, null, 2).replace(/\n/g, EOL);
+
+  if(contentOnly) {
+    //remove curly braces around object properties
+    str = str.split(EOL)
+      .slice(1, -1)
+      .join(EOL)
+  }
+
+  return str;
 };
 
 /* Recursively remove directory, all those above it, if they are empty.

--- a/lib/config.js
+++ b/lib/config.js
@@ -29,6 +29,8 @@ var EOL = require('os').EOL;
 // default newline to the appropriate value for the system
 exports.newLine = EOL;
 
+exports.tab = '  ';
+
 // given a package.json file and an override
 // calculate the package.json file jspm will see
 exports.derivePackageConfig = function(pjson, override) {

--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -352,14 +352,14 @@ Config.prototype.write = function() {
   cfg.map = map;
   cfg.versions = versions;
 
-  if (hasProperties(meta))
-    configContent += 'System.config(' + stringify({ meta: meta }) + ');' + config.newLine + config.newLine;
-
   if (hasProperties(depCache))
     configContent += 'System.config(' + stringify({ depCache: depCache }) + ');' + config.newLine + config.newLine;
 
   if (hasProperties(map))
     configContent += 'System.config(' + stringify({ map: map }) + ');';
+  
+  if (hasProperties(meta))
+    configContent += 'System.config(' + stringify({ meta: meta }) + ');' + config.newLine + config.newLine;
 
   return asp(fs.writeFile)(this.__fileName, configContent);
 };

--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -187,7 +187,7 @@ Config.prototype.read = function(prompts, sync) {
   return ui.input('Enter client baseURL (public folder URL)', self.baseURL || '/')
   .then(function(baseURL) {
     self.baseURL = baseURL;
-     
+
     return ui.confirm('Do you wish to use an ES6 transpiler?', true);
   })
   .then(function(useTranspiler) {
@@ -195,7 +195,7 @@ Config.prototype.read = function(prompts, sync) {
       self.transpiler = 'none';
       return 'none';
     }
-    
+
     return ui.input('Which ES6 transpiler would you like to use, %Babel% or %Traceur%?', self.transpiler);
   })
   .then(function(transpiler) {
@@ -276,6 +276,23 @@ RegistryPath.prototype.write = function() {
   return this.path;
 };
 
+Config.prototype.indentText = function(text) {
+  return text
+    .split(config.newLine)
+    .map(function(line) {
+      return config.tab + line;
+    })
+    .join(config.newLine);
+};
+
+Config.prototype.createConfigBlock = function(key, content) {
+  var configBlock = config.tab + key + ': {' + config.newLine;
+  configBlock += this.indentText(stringify(content, true)) + config.newLine;
+  configBlock += config.tab +'},' + config.newLine + config.newLine;
+
+  return configBlock;
+};
+
 Config.prototype.write = function() {
   // extract over original config to keep initial values
   var cfg = extractObj(this, this.__originalConfig),
@@ -322,7 +339,7 @@ Config.prototype.write = function() {
       delete cfgVersions[v];
   }
 
-  var configContent = '';
+  var configContent = 'System.config({' + config.newLine;
 
   var meta = cfg.meta;
   var depCache = cfg.depCache;
@@ -345,21 +362,29 @@ Config.prototype.write = function() {
     delete cfg.bundles;
 
   if (hasProperties(cfg))
-    configContent += 'System.config(' + stringify(cfg) + ');' + config.newLine + config.newLine;
+    configContent += stringify(cfg, true) + ',' + config.newLine + config.newLine;
 
   cfg.meta = meta;
   cfg.depCache = depCache;
   cfg.map = map;
   cfg.versions = versions;
 
+  if (hasProperties(meta))
+    configContent += this.createConfigBlock('meta', meta);
+
   if (hasProperties(depCache))
-    configContent += 'System.config(' + stringify({ depCache: depCache }) + ');' + config.newLine + config.newLine;
+    configContent += this.createConfigBlock('depCache', depCache);
 
   if (hasProperties(map))
-    configContent += 'System.config(' + stringify({ map: map }) + ');';
-  
-  if (hasProperties(meta))
-    configContent += 'System.config(' + stringify({ meta: meta }) + ');' + config.newLine + config.newLine;
+    configContent += this.createConfigBlock('map', map);
+
+  //remove trailing colon
+  configContent = configContent.slice(0, ("," + config.newLine + config.newLine).length * -1) + config.newLine;
+
+  configContent += '});' + config.newLine;
+
+  //replace quotes around property names where possible
+  configContent = configContent.replace(/([ ]*)"([a-z_$][0-9a-z_$]+)":/ig, '$1$2:');
 
   return asp(fs.writeFile)(this.__fileName, configContent);
 };


### PR DESCRIPTION
Currently, when the config file is written meta information is output before map. If you set meta information for installed libraries, e.g. adding jQuery as dependency for Angular, the meta entry for would not be normalized properly and thus would not have any effect. This change writes the meta config at the end of the SystemJS configuration.