### PR TITLE
correct baseURL default

### DIFF
--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -184,7 +184,7 @@ Config.prototype.read = function(prompts, sync) {
   if (sync)
     throw 'Configuration file has not been initialized. Run jspm init first.';
 
-  return ui.input('Enter client baseURL (public folder URL)', self.baseURL || '/')
+  return ui.input('Enter client baseURL (public folder URL)', self.baseURL || './')
   .then(function(baseURL) {
     self.baseURL = baseURL;
 


### PR DESCRIPTION
When a `config.js` file is created via `jspm init`, the following prompt
is show:

> Enter client baseURL (public folder URL)[./]

However when just hitting enter, the value of `"/"` is entered. This PR
ensures that the default value of `"./"` is used.