### PR TITLE
Include the ability to customise log levels

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -88,8 +88,8 @@ process.on('uncaughtException', function(err) {
       + 'jspm dl-loader [babel|traceur|typescript]\n'
       + '\n'
       + 'jspm resolve --only registry:package@version\n'
-      + '  resolve --only npm:jquery@2.1.1  Resolve all versions of a package to the given version\n'    
-      + '\n'  
+      + '  resolve --only npm:jquery@2.1.1  Resolve all versions of a package to the given version\n'
+      + '\n'
       + 'jspm setmode <mode>\n'
       + '  setmode local                    Switch to locally downloaded libraries\n'
       + '  setmode remote                   Switch to CDN external package sources\n'
@@ -205,6 +205,12 @@ process.on('uncaughtException', function(err) {
 
   var args = process.argv.splice(2),
       options;
+
+  var logArgIndex = args.indexOf('--log');
+  if (logArgIndex > -1) {
+    ui.setLogLevel(args[logArgIndex + 1]);
+    args.splice(logArgIndex, 2);
+  }
 
   switch(args[0]) {
     case 'run':
@@ -405,7 +411,7 @@ process.on('uncaughtException', function(err) {
       var sfxBundle = true;
 
     case 'bundle':
-      options = readOptions(args, ['inject', 'yes', 'skip-source-maps', 'minify', 
+      options = readOptions(args, ['inject', 'yes', 'skip-source-maps', 'minify',
           'no-mangle', 'hires-source-maps', 'no-runtime', 'inline-source-maps'], ['format', 'global-name', 'globals']);
 
       if (options.yes)

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -22,6 +22,13 @@ var logging = true;
 var logBuffer = '';
 var logged = false;
 var cli = module.exports;
+var logLevel = 'debug';
+
+var logMap = {
+  ok: ['ok', 'warn', 'err'],
+  warn: ['warn', 'err'],
+  err: ['err']
+};
 
 // if storing any logs, dump them on exit
 process.on('exit', function() {
@@ -40,6 +47,17 @@ exports.useDefaults = function(_useDefaults) {
   if (_useDefaults === undefined)
     _useDefaults = true;
   useDefaults = _useDefaults;
+};
+
+exports.setLogLevel = function(level) {
+  var defaultLogLevel = 'info';
+  var validLevels = Object.keys(logMap).concat([defaultLogLevel]);
+  if (level && validLevels.indexOf(level) === -1) {
+    exports.log('err', 'Unknown log level: ' + level);
+    logLevel = defaultLogLevel;
+  } else {
+    logLevel = level || defaultLogLevel;
+  }
 };
 
 var format = exports.format = {
@@ -76,8 +94,15 @@ exports.log = function(type, msg) {
   if (type)
     msg = format[type](msg);
 
-  if (logging)
-    return console.log(msg);
+  if (logging) {
+    if ((logLevel === 'debug') ||
+        (type && logMap[logLevel].indexOf(type) > -1)) {
+      console.log(msg);
+    }
+
+    return;
+  }
+
   logBuffer += msg + '\n';
 };
 


### PR DESCRIPTION
This PR adds four new log levels, customised with the `--log` flag.

- `--log debug` (default) everything is logged
- `--log info` info, warnings and errors are logged ('ok' is excluded)
- `--log warn` warnings and errors are logged
- `--log err` only errors are logged

@guybedford I finally found some time to look at #528 and this is my first stab. What do you think?