### PR TITLE
Restore ability to have custom/temporary baseURL on build time

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -27,7 +27,11 @@ var toFileURL = require('./common').toFileURL;
 // just allows cfg object
 function Builder(_config) {
   config.loadSync();
-  SystemJSBuilder.call(this, toFileURL(config.pjson.baseURL));
+  var customBaseURL;
+  if (typeof _config == 'object')
+    customBaseURL = _config.baseURL;
+
+  SystemJSBuilder.call(this, toFileURL(customBaseURL || config.pjson.baseURL));
 
   var cfg = config.loader.getConfig();
 


### PR DESCRIPTION
I was relying on this functionality:
```js
var tmpBuildDir = '.gulp-build`';
var builder = new jspm.Builder({ baseURL: path.resolve(tmpBuildDir) });
```

What I am doing is I am copying files from multiple source directories to one place and on every file before passing it to gulp I am running ng-annotate filter (https://github.com/olov/ng-annotate). This temporary build dir then has to be used as baseURL.

Anyway, this fixes the behavior I need for my project.
