### PR TITLE
Expose the jspm version in the API

### DIFF
--- a/api.js
+++ b/api.js
@@ -56,6 +56,7 @@ API.promptDefaults = function(_useDefaults) {
   ui.useDefaults(_useDefaults);
 };
 
+API.version = require('./package.json').version;
 
 /*
  * Loader API

--- a/test/api.js
+++ b/test/api.js
@@ -5,6 +5,10 @@ var common = require('../lib/common');
 api.setPackagePath('testlibs');
 
 suite('API Calls', function() {
+  test('version', function() {
+    assert(api.version.match(/\d+\.\d+\.\d+(-[^\.]+)?/));
+  });
+
   test('Normalize', function(done) {
     api.normalize('jquery').then(function(normalized) {
       assert(normalized === System.baseURL + 'jspm_packages/github/components/jquery@2.1.4.js');


### PR DESCRIPTION
Couple of times I've written small tools in which I've wanted to just
log the current version of jspm.

@guybedford seemed like a sensible addition to me - what do you think?