### PR TITLE
Adds uglify's dead_code&global_defs support for consistency with SystemJSBuilder.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -94,8 +94,8 @@ process.on('uncaughtException', function(err) {
       + '  setmode local                    Switch to locally downloaded libraries\n'
       + '  setmode remote                   Switch to CDN external package sources\n'
       + '\n'
-      + 'jspm bundle moduleA + module/b [outfile] [--minify] [--no-mangle] [--inject] [--skip-source-maps] [--source-map-contents]\n'
-      + 'jspm bundle-sfx app/main [outfile] [--format <amd|cjs|global>] \n'
+      + 'jspm bundle moduleA + module/b [outfile] [--minify] [--global-defs <json string>] [--no-mangle] [--inject] [--skip-source-maps] [--source-map-contents]\n'
+      + 'jspm bundle-sfx app/main [outfile] [--format <amd|cjs|global>] [--minify] [--global-defs <json string>] \n'
       + 'jspm unbundle                      Remove injected bundle configuration\n'
       + 'jspm depcache moduleName           Stores dep cache in config for flat pipelining\n'
       + '\n'
@@ -417,7 +417,7 @@ process.on('uncaughtException', function(err) {
 
     case 'bundle':
       options = readOptions(args, ['inject', 'yes', 'skip-source-maps', 'minify',
-          'no-mangle', 'hires-source-maps', 'no-runtime', 'inline-source-maps', 'source-map-contents'], ['format', 'global-name', 'globals']);
+          'no-mangle', 'hires-source-maps', 'no-runtime', 'inline-source-maps', 'source-map-contents'], ['format', 'global-name', 'globals', 'global-defs']);
 
       if (options.yes)
         ui.useDefaults();
@@ -437,6 +437,9 @@ process.on('uncaughtException', function(err) {
       if (options.globals)
         options.globalDeps = eval('(' + options.globals + ')');
 
+      if (options['global-defs']) 
+        options.globalDefs = eval('(' + options['global-defs'] + ')');
+      
       var bArgs = options.args.splice(1);
 
       if (bArgs.length === 0)


### PR DESCRIPTION
I can't do conditionally drop code while doing minify bundle via JSPM CLI, which SystemJsBuilder original supported.  

See  

https://github.com/systemjs/builder/blob/master/lib/output.js#L82

at line: 82  

    ast = ast.transform(uglify.Compressor({
        dead_code: true,
        global_defs: globalDefs,
        warnings: false
    }));

So I added this missing part to JSPM.

Adds uglify's dead_code and global definition support to CLI for consistency with SystemJS builder.  