### PR TITLE
Tests fail under windows (CRLF != LF)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,5 @@
     "testlibs",
     "test"
   ],
-  "license": "Apache 2.0"
+  "license": "Apache-2.0"
 }

--- a/test/pjson.js
+++ b/test/pjson.js
@@ -19,7 +19,7 @@ suite('package.json', function() {
       })
       .then(function() {
         var expected = fs.readFileSync('./test/fixtures/pjson/expected/' + input).toString();
-        var actual = fs.readFileSync('./test/outputs/pjson/' + input).toString();
+        var actual = fs.readFileSync('./test/outputs/pjson/' + input).toString().replace(/\r\n/g,'\n');
         try {
           assert.equal(actual, expected);
         }


### PR DESCRIPTION
Files generated by tests contain Windows-style line endings which fail assert equal tests.  These should either be normalized at write or within the unit tests.

Also changed license format so npm doesn't complain.