### PR TITLE
Local config

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -571,9 +571,11 @@ process.on('uncaughtException', function(err) {
 
     case 'c':
     case 'config':
-      var property = args[1];
-      var value = args.splice(2).join(' ');
-      globalConfig.set(property, value);
+      options = readOptions(args, ['local'])
+      var property = options.args[1];
+      var value = options.args.splice(2).join(' ');
+
+      globalConfig.set(property, value, options.local);
       break;
 
     case 'cc':

--- a/cli.js
+++ b/cli.js
@@ -521,7 +521,7 @@ process.on('uncaughtException', function(err) {
       break;
 
     case 'registry':
-      options = readOptions(args, ['yes']);
+      options = readOptions(args, ['yes', 'local']);
 
       if (options.yes)
         ui.useDefaults();
@@ -531,7 +531,7 @@ process.on('uncaughtException', function(err) {
       if (action === 'config') {
         if (!args[2])
           return ui.log('warn', 'You must provide an registry name to configure.');
-        return Promise.resolve(registry.configure(args[2]))
+        return Promise.resolve(registry.configure(args[2], options.local))
         .then(function() {
           ui.log('ok', 'Registry %' + args[2] + '% configured successfully.');
         }, function(err) {
@@ -543,7 +543,7 @@ process.on('uncaughtException', function(err) {
           return ui.log('warn', 'You must provide an registry name to create.');
         if (!args[3])
           return ui.log('warn', 'You must provide the registry module name to generate from.');
-        return Promise.resolve(registry.create(args[2], args[3]))
+        return Promise.resolve(registry.create(args[2], args[3], undefined, options.local))
         .then(function(created) {
           if (created)
             ui.log('ok', 'Enpoint %' + args[2] + '% created successfully.');

--- a/cli.js
+++ b/cli.js
@@ -437,9 +437,9 @@ process.on('uncaughtException', function(err) {
       if (options.globals)
         options.globalDeps = eval('(' + options.globals + ')');
 
-      if (options['global-defs']) 
+      if (options['global-defs'])
         options.globalDefs = eval('(' + options['global-defs'] + ')');
-      
+
       var bArgs = options.args.splice(1);
 
       if (bArgs.length === 0)
@@ -571,7 +571,7 @@ process.on('uncaughtException', function(err) {
 
     case 'c':
     case 'config':
-      options = readOptions(args, ['local'])
+      options = readOptions(args, ['local']);
       var property = options.args[1];
       var value = options.args.splice(2).join(' ');
 

--- a/lib/global-config.js
+++ b/lib/global-config.js
@@ -23,18 +23,38 @@ var dprepend = require('./common').dprepend;
 // global config - automatically created and loaded on startup
 exports.registries = [];
 
+var defaultConfig = {
+  defaultTranspiler: 'babel',
+  defaultRegistry: 'jspm',
+  strictSSL: true,
+  registries: {
+    github: {
+      handler: 'jspm-github',
+      remote: 'https://github.jspm.io'
+    },
+    npm: {
+      handler: 'jspm-npm',
+      remote: 'https://npm.jspm.io'
+    },
+    jspm: {
+      handler: 'jspm-registry',
+      remote: 'https://registry.jspm.io'
+    }
+  }
+};
+
 var config = {
-        // default to globalConfigFilePath
-        current: 'global',
-        global: {
-            path: HOME + path.sep + '.jspm' + path.sep + 'config',
-            content: {}
-        },
-        local: {
-            path: getLocalConfigPath(),
-            content: {}
-        }
-    };
+  // default to globalConfigFilePath
+  current: 'global',
+  global: {
+    path: HOME + path.sep + '.jspm' + path.sep + 'config',
+    content: {}
+  },
+  local: {
+    path: getLocalConfigPath(),
+    content: {}
+  }
+};
 
 // old windows HOME migration
 // can deprecate with jspm 0.15.3
@@ -94,25 +114,7 @@ if (!exports.config.registries && exports.config.endpoints)
 /*
  * Populate default registry configuration
  */
-dprepend(exports.config, {
-  defaultTranspiler: 'babel',
-  defaultRegistry: 'jspm',
-  strictSSL: true,
-  registries: {
-    github: {
-      handler: 'jspm-github',
-      remote: 'https://github.jspm.io'
-    },
-    npm: {
-      handler: 'jspm-npm',
-      remote: 'https://npm.jspm.io'
-    },
-    jspm: {
-      handler: 'jspm-registry',
-      remote: 'https://registry.jspm.io'
-    }
-  }
-});
+dprepend(exports.config, defaultConfig);
 
 // config upgrade paths
 // NB can deprecate with jspm < 10
@@ -154,6 +156,12 @@ function getLocalConfigPath() {
     return configFilePath;
 }
 
+function getDefaultLocalConfigPath() {
+    var configDir = process.env.jspmConfigPath.substr(0, process.env.jspmConfigPath.lastIndexOf('/')) || process.cwd();
+
+    return configDir + path.sep + '.jspmrc';
+}
+
 
 function isLocal() {
     return config.current === 'local';
@@ -162,7 +170,8 @@ function isLocal() {
 
 exports.save = save;
 function save(configToWrite, saveLocal) {
-    var place = saveLocal === true ? 'local' : 'global';
+  var place = saveLocal === true ? 'local' : 'global';
+
   if ( place === 'global' ) {
     try {
       fs.mkdirSync(HOME + path.sep + '.jspm');
@@ -173,7 +182,12 @@ function save(configToWrite, saveLocal) {
     }
   }
 
-  // var configFilePath = saveLocal ? localConfigFilePath : globalConfigFilePath;
+  // If the user wants to save options to a local configuration file that is not
+  // created, we need to create it and extend it with the default config.
+  if ( saveLocal && !config.local.path ) {
+    config.local.path = getDefaultLocalConfigPath();
+    dprepend(configToWrite, defaultConfig);
+  }
 
   try {
     fs.writeFileSync(config[place].path, JSON.stringify(configToWrite, null, 2));

--- a/lib/global-config.js
+++ b/lib/global-config.js
@@ -144,8 +144,14 @@ function loadConfigFile(configFilePath) {
 
 
 function getLocalConfigPath() {
-    var configDir = process.env.jspmConfigPath.substr(0, process.env.jspmConfigPath.lastIndexOf('/')) || process.cwd();
-    var configFilePath;
+    var configDir,
+        configFilePath;
+
+    if ( process.env && typeof process.env.jspmConfigPath === 'string' ) {
+        configDir = process.env.jspmConfigPath.substr(0, process.env.jspmConfigPath.lastIndexOf('/'));
+    } else {
+        configDir =  process.cwd();
+    }
 
     if ( fs.existsSync(configDir + path.sep + '.jspmrc') ) {
         configFilePath = configDir + path.sep + '.jspmrc';

--- a/lib/global-config.js
+++ b/lib/global-config.js
@@ -59,13 +59,15 @@ if (process.env.USERPROFILE && HOME !== process.env.USERPROFILE && !fs.existsSyn
 
 
 if (fs.existsSync(config.global.path)) {
-   config.global.content = loadConfigFile(config.global.path);
+  config.global.content = loadConfigFile(config.global.path);
+  exports.globalConfig = config.global.content;
 }
 
 // Existance of local config has already been checked in getLocalConfigPath()
 if (config.local.path) {
-    config.local.content = loadConfigFile(config.local.path);
-    config.current = 'local';
+  config.local.content = loadConfigFile(config.local.path);
+  exports.localConfig = config.local.content;
+  config.current = 'local';
 }
 
 exports.config = config[config.current].content;
@@ -144,7 +146,7 @@ function getLocalConfigPath() {
     var configFilePath;
 
     if ( fs.existsSync(configDir + path.sep + '.jspmrc') ) {
-        configFilePath = configDir + path.sep + '.jspmrc'
+        configFilePath = configDir + path.sep + '.jspmrc';
     } else if ( fs.existsSync(configDir + path.sep + '.config' + path.sep + '.jspmrc') ) {
         configFilePath = configDir + path.sep + '.config' + path.sep + '.jspmrc';
     }

--- a/lib/global-config.js
+++ b/lib/global-config.js
@@ -22,7 +22,19 @@ var dprepend = require('./common').dprepend;
 
 // global config - automatically created and loaded on startup
 exports.registries = [];
-var globalConfigFile = HOME + path.sep + '.jspm' + path.sep + 'config';
+
+var config = {
+        // default to globalConfigFilePath
+        current: 'global',
+        global: {
+            path: HOME + path.sep + '.jspm' + path.sep + 'config',
+            content: {}
+        },
+        local: {
+            path: getLocalConfigPath(),
+            content: {}
+        }
+    };
 
 // old windows HOME migration
 // can deprecate with jspm 0.15.3
@@ -43,37 +55,28 @@ if (process.env.USERPROFILE && HOME !== process.env.USERPROFILE && !fs.existsSyn
   }
 }
 
-function save() {
-  try {
-    fs.mkdirSync(HOME + path.sep + '.jspm');
-  }
-  catch(e) {
-    if (e.code !== 'EEXIST')
-      throw 'Unable to create jspm system folder\n' + e.stack;
-  }
-  try {
-    fs.writeFileSync(globalConfigFile, JSON.stringify(exports.config, null, 2));
-  }
-  catch(e) {
-    throw 'Unable to write global configuration file\n' + e.stack;
-  }
+
+
+
+if (fs.existsSync(config.global.path)) {
+   config.global.content = loadConfigFile(config.global.path);
 }
-if (fs.existsSync(globalConfigFile)) {
-  try {
-    exports.config = JSON.parse(fs.readFileSync(globalConfigFile).toString() || '{}');
-  }
-  catch(e) {
-    exports.config = {};
-    ui.log('err', 'Unable to read global configuration file.\nEnsure you have read and write access to %' + globalConfigFile + '%.');
-    process.exit(1);
-  }
+
+// Existance of local config has already been checked in getLocalConfigPath()
+if (config.local.path) {
+    config.local.content = loadConfigFile(config.local.path);
+    config.current = 'local';
 }
-else {
+
+exports.config = config[config.current].content;
+
+if ( !exports.config ) {
   exports.config = {};
   if (HOME)
-    save();
+    save(exports.config, isLocal());
 }
-exports.save = save;
+
+
 
 
 // NB can deprecate with jspm 0.14
@@ -115,25 +118,90 @@ if (exports.config.github) {
   dprepend(exports.config.registries.github, exports.config.github);
   delete exports.config.github;
 }
-save();
 
-exports.set = function(name, val) {
-  var nameParts = name.split('.');
 
-  var config = exports.config;
-  var part;
-  while (nameParts.length > 1) {
-    part = nameParts.shift();
-    config[part] = typeof config[part] === 'object' ? config[part] : {};
-    config = config[part];
-  }
-  if (val) {
-    config[nameParts[0]] = val;
-  }
-  else {
-    // If no value is specified, then remove property from config
-    delete config[nameParts[0]];
+save(exports.config, isLocal());
+
+
+
+function loadConfigFile(configFilePath) {
+    var config;
+    try {
+      config = JSON.parse(fs.readFileSync(configFilePath).toString() || '{}');
+    }
+    catch(e) {
+      config = {};
+      ui.log('err', 'Unable to read ' + config.current + ' configuration file.\nEnsure you have read and write access to %' + configFilePath + '%.');
+      process.exit(1);
+    }
+
+    return config;
+}
+
+
+function getLocalConfigPath() {
+    var configDir = process.env.jspmConfigPath.substr(0, process.env.jspmConfigPath.lastIndexOf('/')) || process.cwd();
+    var configFilePath;
+
+    if ( fs.existsSync(configDir + path.sep + '.jspmrc') ) {
+        configFilePath = configDir + path.sep + '.jspmrc'
+    } else if ( fs.existsSync(configDir + path.sep + '.config' + path.sep + '.jspmrc') ) {
+        configFilePath = configDir + path.sep + '.config' + path.sep + '.jspmrc';
+    }
+
+    return configFilePath;
+}
+
+
+function isLocal() {
+    return config.current === 'local';
+}
+
+
+exports.save = save;
+function save(configToWrite, saveLocal) {
+    var place = saveLocal === true ? 'local' : 'global';
+  if ( place === 'global' ) {
+    try {
+      fs.mkdirSync(HOME + path.sep + '.jspm');
+    }
+    catch(e) {
+    if (e.code !== 'EEXIST')
+      throw 'Unable to create jspm system folder\n' + e.stack;
+    }
   }
 
-  save();
-};
+  // var configFilePath = saveLocal ? localConfigFilePath : globalConfigFilePath;
+
+  try {
+    fs.writeFileSync(config[place].path, JSON.stringify(configToWrite, null, 2));
+  }
+  catch(e) {
+    throw 'Unable to write configuration file\n' + e.stack;
+  }
+}
+
+
+exports.set = set;
+function set(name, val, setLocal) {
+    var nameParts = name.split('.');
+
+    var place = setLocal ? 'local' : 'global';
+    var configUpdate = config[place].content;
+
+    var part;
+    while (nameParts.length > 1) {
+        part = nameParts.shift();
+        configUpdate[part] = typeof configUpdate[part] === 'object' ? configUpdate[part] : {};
+        configUpdate = configUpdate[part];
+    }
+    if (val) {
+        configUpdate[nameParts[0]] = val;
+    }
+    else {
+        // If no value is specified, then remove property from config
+        delete configUpdate[nameParts[0]];
+    }
+
+    save(config[place].content, !!setLocal);
+}

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -189,16 +189,17 @@ exports.load = function(registry) {
 
 exports.configure = function(registry, setLocal) {
   var RegistryClass;
+  var updatedConfig;
 
   if ( setLocal ) {
-    config = globalConfig.localConfig || {};
+    updatedConfig = globalConfig.localConfig || {};
   } else {
-    config = globalConfig.globalConfig || {};
+    updatedConfig = globalConfig.globalConfig || {};
   }
 
-  config.registries = config.registries || {};
+  updatedConfig.registries = updatedConfig.registries || {};
 
-  var registryConfig = config.registries[registry] || {};
+  var registryConfig = updatedConfig.registries[registry] || {};
 
   if (!registryConfig.handler)
     throw 'Registry %' + registry + '% not found.';
@@ -222,27 +223,29 @@ exports.configure = function(registry, setLocal) {
     delete _config.name;
     delete _config.strictSSL;
     _config.handler = handler;
-    config.registries[registry] = _config;
+    updatedConfig.registries[registry] = _config;
   })
   .then(function() {
-    globalConfig.save(config, setLocal);
+    globalConfig.save(updatedConfig, setLocal);
   });
 };
 
 // jspm registry create mycompany jspm-github
 // creates a custom registry based on the given handler
 exports.create = function(name, handler, override, setLocal) {
+  var updatedConfig;
+
   if ( setLocal ) {
-    config = globalConfig.localConfig = globalConfig.localConfig || {};
+    updatedConfig = globalConfig.localConfig = globalConfig.localConfig || {};
   } else {
-    config = globalConfig.globalConfig = globalConfig.globalConfig || {};
+    updatedConfig = globalConfig.globalConfig = globalConfig.globalConfig || {};
   }
 
-  config.registries = config.registries || {};
+  updatedConfig.registries = updatedConfig.registries || {};
 
   // handle override prompts etc
-  if (!override && config.registries[name]) {
-    if (config.registries[name].handler === handler)
+  if (!override && updatedConfig.registries[name]) {
+    if (updatedConfig.registries[name].handler === handler)
       return ui.confirm('Registry %' + name + '% already exists. Do you want to reconfigure it now?')
       .then(function(configure) {
         if (configure)
@@ -255,7 +258,7 @@ exports.create = function(name, handler, override, setLocal) {
           return false;
       });
     else
-      return ui.confirm('Registry %' + name + '% already exists, but based on `' + config.registries[name].handler + '`. Are you sure you want to override it?')
+      return ui.confirm('Registry %' + name + '% already exists, but based on `' + updatedConfig.registries[name].handler + '`. Are you sure you want to override it?')
       .then(function(override) {
         if (override)
           return Promise.resolve(exports.create(name, handler, true, setLocal));
@@ -263,7 +266,7 @@ exports.create = function(name, handler, override, setLocal) {
       });
   }
 
-  var registryConfig = config.registries[name] = config.registries[name] || {};
+  var registryConfig = updatedConfig.registries[name] = updatedConfig.registries[name] || {};
   registryConfig.handler = handler;
 
   // load the registry and configure it

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -187,12 +187,22 @@ exports.load = function(registry) {
   }
 };
 
-exports.configure = function(registry) {
-  var registryConfig = globalConfig.config.registries[registry] || {},
-      RegistryClass;
+exports.configure = function(registry, setLocal) {
+  var RegistryClass;
+
+  if ( setLocal ) {
+    config = globalConfig.localConfig || {};
+  } else {
+    config = globalConfig.globalConfig || {};
+  }
+
+  config.registries = config.registries || {};
+
+  var registryConfig = config.registries[registry] || {};
 
   if (!registryConfig.handler)
     throw 'Registry %' + registry + '% not found.';
+
 
   var handler = registryConfig.handler;
   delete registryConfig.handler;
@@ -212,24 +222,31 @@ exports.configure = function(registry) {
     delete _config.name;
     delete _config.strictSSL;
     _config.handler = handler;
-    globalConfig.config.registries[registry] = _config;
+    config.registries[registry] = _config;
   })
   .then(function() {
-    globalConfig.save();
+    globalConfig.save(config, setLocal);
   });
 };
 
 // jspm registry create mycompany jspm-github
 // creates a custom registry based on the given handler
-exports.create = function(name, handler, override) {
+exports.create = function(name, handler, override, setLocal) {
+  if ( setLocal ) {
+    config = globalConfig.localConfig = globalConfig.localConfig || {};
+  } else {
+    config = globalConfig.globalConfig = globalConfig.globalConfig || {};
+  }
+
+  config.registries = config.registries || {};
 
   // handle override prompts etc
-  if (!override && globalConfig.config.registries[name]) {
-    if (globalConfig.config.registries[name].handler === handler)
+  if (!override && config.registries[name]) {
+    if (config.registries[name].handler === handler)
       return ui.confirm('Registry %' + name + '% already exists. Do you want to reconfigure it now?')
       .then(function(configure) {
         if (configure)
-          return Promise.resolve(exports.configure(name))
+          return Promise.resolve(exports.configure(name, setLocal))
           .then(function() {
             ui.log('ok', 'Registry %' + name + '% configured successfully.');
             return false;
@@ -238,17 +255,17 @@ exports.create = function(name, handler, override) {
           return false;
       });
     else
-      return ui.confirm('Registry %' + name + '% already exists, but based on `' + globalConfig.config.registries[name].handler + '`. Are you sure you want to override it?')
+      return ui.confirm('Registry %' + name + '% already exists, but based on `' + config.registries[name].handler + '`. Are you sure you want to override it?')
       .then(function(override) {
         if (override)
-          return Promise.resolve(exports.create(name, handler, true));
+          return Promise.resolve(exports.create(name, handler, true, setLocal));
         return false;
       });
   }
 
-  var registryConfig = globalConfig.config.registries[name] = globalConfig.config.registries[name] || {};
+  var registryConfig = config.registries[name] = config.registries[name] || {};
   registryConfig.handler = handler;
 
   // load the registry and configure it
-  return exports.configure(name);
+  return exports.configure(name, setLocal);
 };


### PR DESCRIPTION
This is a proposed fix for issue #190. 

It creates a `--local` flag for `jspm config` and `jspm registry`. If the `--local` flag is provided the configuration will be saved in `./.jspmrc`or `./.config/.jspmrc`, in that order.

I couldn't really wrap my head around if and how to add tests for the changes, so no tests are added. I'd be happy to fix this if there is a standard to follow.