### PR TITLE
Honor existing line endings in config.js

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -18,8 +18,7 @@ require('core-js/es6/string');
 var asp = require('rsvp').denodeify;
 var fs = require('graceful-fs');
 var path = require('path');
-var newLine = require('./config').newLine;
-var tab = require('./config').tab;
+var chars = require('./config').chars;
 
 exports.toFileURL = function toFileURL(path) {
   return 'file://' + (process.platform.match(/^win/) ? '/' : '') + path.replace(/\\/g, '/');
@@ -144,7 +143,7 @@ exports.getRedirectContents = function(format, main) {
 };
 
 exports.stringify = function (subject) {
-  return JSON.stringify(subject, null, tab).replace(/\n/g, newLine);
+  return JSON.stringify(subject, null, chars.tab).replace(/\n/g, chars.newLine);
 };
 
 /* Recursively remove directory, all those above it, if they are empty.

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,9 +15,10 @@
  */
 exports.HOME = process.env.LOCALAPPDATA || process.env.HOME || process.env.HOMEPATH;
 
-// default newline to the appropriate value for the system
-exports.newLine = require('os').EOL;
-exports.tab = '  ';
+exports.chars = {
+  newLine: require('os').EOL,
+  tab: '  '
+};
 
 var ui = require('./ui');
 var fs = require('graceful-fs');

--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -64,9 +64,9 @@ Config.prototype.read = function(prompts, sync) {
   try {
     source = fs.readFileSync(this.__fileName);
     if (source && /\r\n/.test(source)) {
-      chars.newLine = "\r\n";
+      chars.newLine = '\r\n';
     } else {
-      chars.newLine = "\n";
+      chars.newLine = '\n';
     }
   }
   catch(e) {

--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -16,6 +16,7 @@
 
 var registry = require('../registry');
 var config = require('../config');
+var chars = require('../config').chars;
 var extend = require('../common').extend;
 var hasProperties = require('../common').hasProperties;
 var fs = require('graceful-fs');
@@ -62,6 +63,11 @@ Config.prototype.read = function(prompts, sync) {
   var source;
   try {
     source = fs.readFileSync(this.__fileName);
+    if (source && /\r\n/.test(source)) {
+      chars.newLine = "\r\n";
+    } else {
+      chars.newLine = "\n";
+    }
   }
   catch(e) {
     source = '';
@@ -366,11 +372,11 @@ Config.prototype.write = function() {
 
   var configContent = stringify(outConfig)
       // add a newline before "meta", "depCache", "map" blocks, removing quotes
-      .replace(new RegExp('^' + config.tab + '"(meta|depCache|map|packages)"', 'mg'), config.newLine + config.tab + '$1')
+      .replace(new RegExp('^' + chars.tab + '"(meta|depCache|map|packages)"', 'mg'), chars.newLine + chars.tab + '$1')
       // remove quotes on first-level letter-based properties
-      .replace(new RegExp('^' + config.tab + '"(\\w+)"', 'mg'), config.tab + '$1');
+      .replace(new RegExp('^' + chars.tab + '"(\\w+)"', 'mg'), chars.tab + '$1');
 
-  return asp(fs.writeFile)(this.__fileName, 'System.config(' + configContent + ');' + config.newLine);
+  return asp(fs.writeFile)(this.__fileName, 'System.config(' + configContent + ');' + chars.newLine);
 };
 module.exports = Config;
 

--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -15,6 +15,7 @@
  */
 
 var config = require('../config');
+var chars = require('../config').chars;
 var path = require('path');
 var extend = require('../common').extend;
 var hasProperties = require('../common').hasProperties;
@@ -96,7 +97,7 @@ PackageJSON.prototype.read = function(prompts, sync) {
     // if dependencies already existing, override with empty dependencies
     if (self.originalPjson.dependencies)
       pjson.dependencies = {};
-    if (self.originalPjson.devDependencies) 
+    if (self.originalPjson.devDependencies)
       pjson.devDependencies = {};
   }
 
@@ -198,7 +199,7 @@ PackageJSON.prototype.write = function() {
 
   pjson.directories = alphabetize(directories);
 
-  set('configFile', this.configFile, winPath(path.relative(this.dir, this.configFile)));    
+  set('configFile', this.configFile, winPath(path.relative(this.dir, this.configFile)));
 
   pjson.map = alphabetize(this.map);
 
@@ -228,7 +229,7 @@ PackageJSON.prototype.write = function() {
   }
 
   // NB check that the file hasn't changed since we opened it and if so, prompt
-  return asp(fs.writeFile)(this.fileName, stringify(this.originalPjson) + config.newLine);
+  return asp(fs.writeFile)(this.fileName, stringify(this.originalPjson) + chars.newLine);
 };
 
 function writeDependencies(dependencies, registry) {


### PR DESCRIPTION
If you are working with an OS that uses different line endings than your config.js, it's pretty annoying that these will be overwritten.

I think it would be nice to honor the existing line endings. This PR will also override the line endings in the package.json depending on the characters used in the config.js, but in my case this is also a nice side effect.

Probably the best approach would be to save the existing line endings somewhere in the corresponding configs (package, loader) and use them explicitly when writing the file.