### PR TITLE
Add support of non '.js' main

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -759,17 +759,28 @@ exports.createMain = function(pkg, pjson, downloadDir) {
       return true;
     }
 
-    if (main) {
-      if (main.startsWith('./'))
-        main = main.substr(2);
-      if (main.endsWith('.js'))
-        main = main.substr(0, main.length - 3);
+    if (!main)
+      return false;
+
+    if (main.startsWith('./')) {
+      main = main.substr(2);    
     }
+    
+    return new Promise(function(resolve) {
+      // Check to see if main points to an actual file or not
+      // i.e. does it include extension.
+      mainPath = path.resolve(downloadDir, main);
+      fs.exists(mainPath, resolve);
+    });
+  }).then(function(exists) {
+    if (exists)
+      return exists;
 
     main = main || 'index';
 
-    // try the package.json main
     return new Promise(function(resolve) {
+      // `main` does not have extension (or it does not point to an actual file).
+      // Try again with `.js` extension
       mainPath = path.resolve(downloadDir, main + '.js');
       fs.exists(mainPath, resolve);
     });


### PR DESCRIPTION
One custom step need is to add `packages: { "myModule": { defaultExtension: "{myExtension, e.g. ts}" } }`, which is ok to do before 0.17