### PR TITLE
Add `--production` flag to not install dev dependencies.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -228,7 +228,7 @@ process.on('uncaughtException', function(err) {
     case 'i':
     case 'install':
       options = readOptions(args, ['force', 'link', 'yes', 'lock', 'latest',
-                                   'unlink', 'quick', 'dev', 'edge'], ['override']);
+                                   'unlink', 'quick', 'dev', 'edge', 'production'], ['override']);
       options.inject = inject;
       options.update = doUpdate;
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -71,6 +71,7 @@ var installing = {
  * options.unlink
  * options.quick - lock and skip hash checks
  * options.dev - store in devDependencies
+ * options.production - only install dependencies, not devDependencies
  * options.update - we're updating the targets
  *
  * options.summary - show fork and resolution summary
@@ -95,8 +96,12 @@ exports.install = function(targets, options) {
       options.lock = true;
 
     var d, existingTargets = {};
-    for (d in config.pjson.devDependencies)
-      existingTargets[d] = config.pjson.devDependencies[d];
+
+    if (!options.production) {
+      for (d in config.pjson.devDependencies)
+        existingTargets[d] = config.pjson.devDependencies[d];
+    }
+
     for (d in config.pjson.dependencies)
       existingTargets[d] = config.pjson.dependencies[d];
 


### PR DESCRIPTION
Closes #1297.

@guybedford I'm not sure if it's as simple as this - but a quick test showed that this works fine for the base case. I feel like I might have missed something though.