### PR TITLE
Add file locking for global config

### DIFF
--- a/lib/global-config.js
+++ b/lib/global-config.js
@@ -18,7 +18,10 @@ var ui = require('./ui');
 var fs = require('graceful-fs');
 var path = require('path');
 var HOME = require('./config').HOME;
+var lockFile = require('proper-lockfile');
 var dprepend = require('./common').dprepend;
+var readJSONSync = require('./common').readJSONSync;
+var stringify = require('./common').stringify;
 
 // global config - automatically created and loaded on startup
 exports.registries = [];
@@ -43,38 +46,11 @@ if (process.env.USERPROFILE && HOME !== process.env.USERPROFILE && !fs.existsSyn
   }
 }
 
-function save() {
-  try {
-    fs.mkdirSync(HOME + path.sep + '.jspm');
-  }
-  catch(e) {
-    if (e.code !== 'EEXIST')
-      throw 'Unable to create jspm system folder\n' + e.stack;
-  }
-  try {
-    fs.writeFileSync(globalConfigFile, JSON.stringify(exports.config, null, 2));
-  }
-  catch(e) {
-    throw 'Unable to write global configuration file\n' + e.stack;
-  }
-}
-if (fs.existsSync(globalConfigFile)) {
-  try {
-    exports.config = JSON.parse(fs.readFileSync(globalConfigFile).toString() || '{}');
-  }
-  catch(e) {
-    exports.config = {};
-    ui.log('err', 'Unable to read global configuration file.\nEnsure you have read and write access to %' + globalConfigFile + '%.');
-    process.exit(1);
-  }
-}
-else {
-  exports.config = {};
-  if (HOME)
-    save();
-}
-exports.save = save;
+// Begin file lock
+lock();
 
+// after loading, we'll dprepend all defaults to `exports.config` in this `try` block
+exports.config = readJSONSync(globalConfigFile);
 
 // NB can deprecate with jspm 0.14
 if (!exports.config.defaultRegistry && exports.config.registry)
@@ -86,9 +62,14 @@ if (!exports.config.registries && exports.config.endpoints)
 // delete exports.config.registry;
 // delete exports.config.endpoints;
 
-/*
- * Populate default registry configuration
- */
+// config upgrade paths
+// NB can deprecate with jspm < 10
+if (exports.config.github) {
+  dprepend(exports.config.registries.github, exports.config.github);
+  delete exports.config.github;
+}
+
+// populate default registry configuration
 dprepend(exports.config, {
   defaultTranspiler: 'babel',
   defaultRegistry: 'jspm',
@@ -109,13 +90,35 @@ dprepend(exports.config, {
   }
 });
 
-// config upgrade paths
-// NB can deprecate with jspm < 10
-if (exports.config.github) {
-  dprepend(exports.config.registries.github, exports.config.github);
-  delete exports.config.github;
+if (HOME)
+  save();
+// end file lock
+unlock();
+
+function save() {
+  try {
+    fs.mkdirSync(HOME + path.sep + '.jspm');
+  }
+  catch (e) {
+    if (e.code !== 'EEXIST')
+      throw 'Unable to create jspm system folder\n' + e.stack;
+  }
+  try {
+    lock();
+    var existing = readJSONSync(globalConfigFile);
+    // only write to a new file if the local changes are different
+    if (JSON.stringify(existing) != JSON.stringify(exports.config)) {
+      fs.writeFileSync(globalConfigFile, stringify(exports.config));
+    }
+  }
+  catch (e) {
+    throw 'Unable to write global configuration file\n' + e.stack;
+  }
+  finally {
+    unlock();
+  }
 }
-save();
+exports.save = save;
 
 exports.set = function(name, val) {
   var nameParts = name.split('.');
@@ -137,3 +140,38 @@ exports.set = function(name, val) {
 
   save();
 };
+
+var _unlock;
+function lock() {
+  if (!_unlock) {
+    try {
+      _unlock = lockFile.lockSync(globalConfigFile, {
+        retries: {
+          retries: 10,
+          minTimeout: 20,
+          maxTimeout: 300,
+          randomize: true
+        },
+        realpath: false
+      });
+    } catch (e) {
+      if (e.code === 'ELOCKED')
+        throw 'Unable to lock global config file %' + globalConfigFile + '%, not overwriting';
+    }
+  }
+}
+function unlock() {
+  if (_unlock) {
+    _unlock();
+    _unlock = undefined;
+  }
+}
+// Map SIGINT & SIGTERM to process exit
+// so that lockfile removes the lockfile automatically
+process
+  .once('SIGINT', function () {
+    process.exit(1);
+  })
+  .once('SIGTERM', function () {
+    process.exit(1);
+  });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "minimatch": "^2.0.8",
     "mkdirp": "~0.5.1",
     "ncp": "^2.0.0",
+    "proper-lockfile": "^1.0.2",
     "request": "^2.58.0",
     "rimraf": "^2.4.0",
     "rsvp": "^3.0.18",

--- a/test/fixtures/global-config/.jspm/config
+++ b/test/fixtures/global-config/.jspm/config
@@ -1,0 +1,13 @@
+{
+  "defaultTranspiler": "babel",
+  "defaultRegistry": "jspm",
+  "strictSSL": true,
+  "registries": {
+    "test": {
+      "handler": "dont-overwrite-me"
+    },
+    "github": {
+      "auth": "dont-overwrite-me"
+    }
+  }
+}

--- a/test/fixtures/global-config/expected/combined.json
+++ b/test/fixtures/global-config/expected/combined.json
@@ -1,0 +1,23 @@
+{
+  "defaultTranspiler": "babel",
+  "defaultRegistry": "jspm",
+  "strictSSL": true,
+  "registries": {
+    "test": {
+      "handler": "dont-overwrite-me"
+    },
+    "github": {
+      "auth": "dont-overwrite-me",
+      "handler": "jspm-github",
+      "remote": "https://github.jspm.io"
+    },
+    "npm": {
+      "handler": "jspm-npm",
+      "remote": "https://npm.jspm.io"
+    },
+    "jspm": {
+      "handler": "jspm-registry",
+      "remote": "https://registry.jspm.io"
+    }
+  }
+}

--- a/test/fixtures/global-config/expected/default.json
+++ b/test/fixtures/global-config/expected/default.json
@@ -1,0 +1,19 @@
+{
+  "defaultTranspiler": "babel",
+  "defaultRegistry": "jspm",
+  "strictSSL": true,
+  "registries": {
+    "github": {
+      "handler": "jspm-github",
+      "remote": "https://github.jspm.io"
+    },
+    "npm": {
+      "handler": "jspm-npm",
+      "remote": "https://npm.jspm.io"
+    },
+    "jspm": {
+      "handler": "jspm-registry",
+      "remote": "https://registry.jspm.io"
+    }
+  }
+}

--- a/test/global-config.js
+++ b/test/global-config.js
@@ -1,0 +1,93 @@
+var fs = require('fs');
+var path = require('path');
+var child_process = require('child_process');
+
+var fakeHomePath = path.resolve('./test/fixtures/global-config/');
+var fakeConfigFile = path.resolve(fakeHomePath, '.jspm/config');
+var defaultConfigFile = path.resolve(fakeHomePath, 'expected/default.json');
+var combinedConfigFile = path.resolve(fakeHomePath, 'expected/combined.json');
+
+suite('global-config', function () {
+
+  test('should be able to run concurrent processes', function (done) {
+    resetConfigFile();
+    // we'll fake the HOME path for these child processes,
+    // so that global-config.js will look in ./fixtures/.jspm/config
+    // instead of mucking with the real config file
+    var original = fs.readFileSync(fakeConfigFile).toString();
+
+    // we'll make 20 parallel processes
+    var child = require.resolve('../lib/global-config');
+    for (var i = 0; i < 20; i++) {
+      child_process.spawn(process.execPath, [child], {env: {HOME: fakeHomePath}})
+        .on('exit', onExit);
+    }
+
+    // we'll wait until all of the processes exit with this function. once
+    // `exits` is `20`, we know all processes have exited, and we can assert
+    var exits = 0;
+    function onExit() {
+      exits++;
+      if (exits === 20) {
+        // make sure that it is still our original file, and that
+        // hasn't been overwritten with the jspm default config
+        var actual = fs.readFileSync(fakeConfigFile).toString();
+        var expected = fs.readFileSync(combinedConfigFile).toString().replace(/\n$/, '');
+
+        assert.equal(actual, expected);
+        done();
+      }
+    }
+
+  });
+
+  test('should create a new file if one does not exist', function (done) {
+    fs.unlinkSync(fakeConfigFile);
+    var child = require.resolve('../lib/global-config');
+    child_process.spawn(process.execPath, [child], {env: {HOME: fakeHomePath}})
+      .on('exit', function () {
+        var actual = fs.readFileSync(fakeConfigFile).toString();
+        var expected = fs.readFileSync(defaultConfigFile).toString().replace(/\n$/, '');
+
+        assert.equal(actual, expected);
+        done();
+      });
+  });
+
+  test('should create the directory if it does not exist', function (done) {
+    fs.unlinkSync(fakeConfigFile);
+    fs.rmdir(path.join(fakeHomePath, '.jspm'));
+
+    var child = require.resolve('../lib/global-config');
+    child_process.spawn(process.execPath, [child], {env: {HOME: fakeHomePath}})
+      .on('exit', function () {
+        var actual = fs.readFileSync(fakeConfigFile).toString();
+        var expected = fs.readFileSync(defaultConfigFile).toString().replace(/\n$/, '');
+
+        assert.equal(actual, expected);
+        done();
+      });
+  });
+
+  after(resetConfigFile);
+
+});
+
+/**
+ * rewrites our fake config file with the default JSON
+ */
+function resetConfigFile() {
+  fs.writeFileSync(fakeConfigFile, JSON.stringify({
+    defaultTranspiler: 'babel',
+    defaultRegistry: 'jspm',
+    strictSSL: true,
+    registries: {
+      test: {
+        handler: 'dont-overwrite-me'
+      },
+      github: {
+        auth: 'dont-overwrite-me'
+      }
+    }
+  }, null, '  '));
+}


### PR DESCRIPTION
This pull request should solve issues file locking issues raised in #1198 and #1076.

Basically, I rearranged the global-config.js file to do this, in order:

   1) lock ~/.jspm/config
   2) read ~/.jspm/config
   3) apply the defaults/migrations with `dprepend`
   4) save the config _only_ if it is different from the file on disk.
   5) unlock the file

This allows multiple jspm processes to start/run concurrently, without accidentally overwriting the global config when another process is writing to it.