### PR TITLE
Allow boolean and integer types with jspm config CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -205,6 +205,17 @@ process.on('uncaughtException', function(err) {
     return options;
   }
 
+  // this will get a value in its true type from the CLI
+  function readValue(val) {
+    if (val === 'true' || val === 'false') {
+      return eval(val);
+    } else if (!isNaN(parseInt(val))) {
+      return parseInt(val);
+    } else {
+      return val;
+    }
+  }
+
   // [].concat() to avoid mutating the given process.argv
   var args = process.argv.slice(2),
       options;
@@ -573,7 +584,7 @@ process.on('uncaughtException', function(err) {
     case 'c':
     case 'config':
       var property = args[1];
-      var value = args.splice(2).join(' ');
+      var value = readValue(args.splice(2).join(' '));
       globalConfig.set(property, value);
       break;
 

--- a/lib/global-config.js
+++ b/lib/global-config.js
@@ -130,7 +130,7 @@ exports.set = function(name, val) {
     config[part] = typeof config[part] === 'object' ? config[part] : {};
     config = config[part];
   }
-  if (val) {
+  if (val !== undefined) {
     config[nameParts[0]] = val;
   }
   else {


### PR DESCRIPTION
One more small code change for your review. Right now, `jspm config strictSSL false` will set the value of the `strictSSL` key in `~/.jspm/config` to string `"false"`, instead of boolean false. Same for integers (eg registries.github.maxRepoSize).

This code change will read "true" and "false" from the command line and convert them to booleans, and convert strings of numbers to integers.