### PR TITLE
Use `package.son` format if defined in createMain()

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -827,9 +827,9 @@ exports.createMain = function(pkg, pjson, downloadDir) {
     .then(function(source) {
       if (typeof source == 'undefined')
         return;
-      var detected = build.detectFormat(source.toString());
+      var format = pjson.format || build.detectFormat(source.toString()).format;
 
-      return asp(fs.writeFile)(mainFile, getRedirectContents(detected.format, pkg.exactName + '/' + main));
+      return asp(fs.writeFile)(mainFile, getRedirectContents(format, pkg.exactName + '/' + main));
     });
   });
 };


### PR DESCRIPTION
Fix #1415