### PR TITLE
Allow linking through module api

### DIFF
--- a/api.js
+++ b/api.js
@@ -16,6 +16,7 @@
 
 var install = require('./lib/install');
 var bundle = require('./lib/bundle');
+var link = require('./lib/link');
 var core = require('./lib/core');
 var ui = require('./lib/ui');
 var EventEmitter = require('events').EventEmitter;
@@ -150,4 +151,17 @@ API.uninstall = function(names) {
 
 API.dlLoader = function(transpiler) {
   return core.checkDlLoader(transpiler);
+};
+
+/**
+ * Link a local folder as an installable package
+ * @param {string} linkTargetDir Filesystem path to package source directory
+ * @param {string} linkName Uncanonical package name used to register the link target (the version before map/path rules are applied)
+ * @param {object} options
+ * @param {boolean} options.force
+ * @param {boolean} options.quick
+ * @returns {Promise}
+ */
+API.link = function(linkTargetDir, linkName, options) {
+  return link.link(linkTargetDir, linkName, options || {});
 };


### PR DESCRIPTION
I am developing an autoinstaller plugin for systemjs-builder and was faced by the need to do local linking during development by using the module api. Just added a new function export `link(...)` and delegated to `lib/link.link(...)` .