### PR TITLE
Find linked package root to read package.json, fixes #1462

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -520,7 +520,12 @@ exports.download = function(pkg, options, installDeps, installPeerDeps) {
       if (options.linked && !options.unlink) {
         ui.log('info', 'Processing linked package `' + pkg.exactName + '`');
 
-        return Promise.resolve(readJSON(path.resolve(downloadDir, 'package.json')))
+        return asp(fs.realpath)(downloadDir)
+        .then(function(dir) {
+          return findPackageRoot(pkg, dir);
+        }).then(function(root) {
+          return readJSON(path.resolve(root, 'package.json'));
+        })
         .then(function(packageConfig) {
           return derivePackageConfig(pkg, packageConfig, override);
         })
@@ -705,6 +710,20 @@ exports.download = function(pkg, options, installDeps, installPeerDeps) {
     });
   }));
 };
+
+function findPackageRoot(pkg, testRoot, prevRoot) {
+  if (prevRoot === testRoot) {
+    ui.log('err', 'Linked package `' + pkg.exactname + '` no longer has a package.json');
+    throw 'Error processing linked package `' + pkg.exactName + '`.';
+  }
+
+  return asp(fs.stat)(path.join(testRoot, 'package.json'))
+  .then(function() { return testRoot; })
+  .catch(function() {
+    return findPackageRoot(path.dirname(testRoot), testRoot);
+  });
+}
+
 
 function getPackageHash(dir) {
   return new Promise(function(resolve) {


### PR DESCRIPTION
There might be a preference for a better error message, but that error condition should be nearly non existant. Only case is if a user deletes the linked package.json after sometime and then relinks the package.