### PR TITLE
Fix bug creeped satisfying JSHint top level functions

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -720,7 +720,7 @@ function findPackageRoot(pkg, testRoot, prevRoot) {
   return asp(fs.stat)(path.join(testRoot, 'package.json'))
   .then(function() { return testRoot; })
   .catch(function() {
-    return findPackageRoot(path.dirname(testRoot), testRoot);
+    return findPackageRoot(pkg, path.dirname(testRoot), testRoot);
   });
 }
 


### PR DESCRIPTION
Sorry about this. To satisfy the JSHint run on the CI I needed to move the function declaration to the top level and thought I had caught adding `pkg` for the error message. However I missed the recursive call and when I tried again today linking was infinite looping.