### PR TITLE
Make install typo isntall work

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -240,6 +240,7 @@ process.on('uncaughtException', function(err) {
       var doUpdate = !inject;
 
     case 'i':
+    case 'isntall':
     case 'install':
       options = readOptions(args, ['force', 'link', 'yes', 'lock', 'latest',
                                    'unlink', 'quick', 'dev', 'edge', 'production'], ['override']);


### PR DESCRIPTION
I'm constantly mistyping `jspm install` as `jspm isntall`. This PR allows JSPM to work when the typo is typed.