### PR TITLE
0.17 beta - Fix tab detection on windows/CRLF line-endings

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -528,7 +528,7 @@ function detectStyle(string) {
 
   // best-effort tab detection
   // yes this is overkill, but it avoids possibly annoying edge cases
-  var tabSpaces = string.match(/^[ \t]*/mg) || [];
+  var tabSpaces = string.split(style.newline).map(function(line) { return line.match(/^[ \t]*/)[0]; }) || [];
   var tabDifferenceFreqs = {};
   var lastLength = 0;
   tabSpaces.forEach(function(tabSpace) {


### PR DESCRIPTION
Multiline regexes match on both CR and LF, causing tabSpaces to alternate between actual lines and blank lines, messing up detection. (I commonly got 6 or 10 spaced config files...not fun.)
A fix is to split by the detected line ending and then match on every line (with single line regex)
Ideally it'd be nice to find a regex that just works for both types, but I couldn't see how js global regexes capture groups (i.e. you'd match on the full line but only capture spaces at start)