### PR TITLE
0.17: Change "jspm.js" to "jspm.config.js" in upgrade notes

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -286,7 +286,7 @@ exports.load = function(prompts, allowNoConfig) {
         ui.log('ok', 'jspm 0.17-beta upgrade complete.\n\n' +
           'Some important breaking changes to note:\n\n' +
           wordWrap('• The %config.js% file has been renamed to %jspm.config.js% unless you were already using a custom config path for this.\n', process.stdout.columns - 4, 2, 0, true) + '\n' + 
-          wordWrap('• There is now a new config file, %jspm.browser.js%, which must be included _before_ %jspm.js% in the browser.\n', process.stdout.columns - 4, 2, 0, true) + '\n' + 
+          wordWrap('• There is now a new config file, %jspm.browser.js%, which must be included _before_ %jspm.config.js% in the browser.\n', process.stdout.columns - 4, 2, 0, true) + '\n' + 
           wordWrap('• js extensions are required for module imports not inside packages. Eg %System.import(\'./test\')% will need to become %System.import(\'./test.js\')%.', process.stdout.columns - 4, 2, 0, true) + '\n' + 
           '\nThere are also other smaller breaking changes in this release, described in the full changelog at https://github.com/jspm/jspm-cli/releases/tag/0.17.0-beta.\n' + '\n' + 
           'Please report any issues or feedback to help improve this release and thanks for testing it out.');


### PR DESCRIPTION
Got a little confused when upgrading to 0.17, as there was no file named `jspm.js`. I'm assuming this should read `jspm.config.js`.