### PR TITLE
Fix skip encode names

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -476,7 +476,7 @@ process.on('uncaughtException', function(err) {
         options.globalDefs = eval('(' + options['global-defs'] + ')');
 
       if (options['skip-encode-names'])
-        options.encodeNames = options['skip-encode-names'];
+        options.encodeNames = !options['skip-encode-names'];
 
       if (options['skip-rollup'])
         options.rollup = !options['skip-rollup'];


### PR DESCRIPTION
Alternatively this and skip-rollup could be moved to not even need an if statement (similar to `no-mangle`), which looks a little cleaner