### PR TITLE
Fix build errors not exiting with 1

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -231,6 +231,7 @@ exports.build = function(expression, fileName, opts) {
   })
   .catch(function(e) {
     ui.log('err', e.stack || e);
+    throw e;
   });
 };
 


### PR DESCRIPTION
I noticed my CI builds were completing even though the build had an error, this should fix it.
The error thrown here is caught up the pipeline in cli.js where it correctly `process.exit(1)`'s.