### PR TITLE
Watch the current working directory instead of the lowest directory

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -116,7 +116,7 @@ exports.depCache = function(expression) {
   var systemBuilder = new Builder();
 
   expression = expression || config.loader.main;
-  
+
   ui.log('info', 'Injecting the traced dependency tree for `' + expression + '`...');
 
   return systemBuilder.trace(expression, { browser: true })
@@ -217,7 +217,7 @@ function logBuild(outFile, opts) {
 // options.minify, options.sourceMaps
 exports.build = function(expression, fileName, opts) {
   var systemBuilder = new Builder();
-  
+
   opts = opts || {};
 
   return Promise.resolve()
@@ -267,7 +267,7 @@ function buildWatch(files, fn) {
       lowestDir = path.dirname(file);
   });
 
-  var watcher = sane(lowestDir, { glob: files });
+  var watcher = sane(process.cwd(), { glob: files });
   watcher.on('ready', function() {
     ui.log('info', 'Watching %' + lowestDir + '% for changes...');
   });
@@ -308,13 +308,13 @@ function logTree(modules, inlineMap) {
     modules.sort().forEach(function(name) {
       if (inlinedModules.indexOf(name) == -1)
         ui.log('info', '  `' + name + '`');
-      
+
       if (inlineMap[name])
         logDepTree(inlineMap[name], true);
     });
   else
     logDepTree(modules, false);
-  
+
   if (inlinedModules.length || inlineMap === true)
     ui.log('info', '');
 
@@ -327,7 +327,7 @@ function logTree(modules, inlineMap) {
 
 function logDepTree(items, firstParent) {
   items.forEach(function(item, index) {
-    ui.log('info', '  `' + (items.length == 1 ? '──' : index == items.length - 1 ? '└─' : index == 0 && !firstParent ? '┌─' : '├─') + ' %' + item + '%`');  
+    ui.log('info', '  `' + (items.length == 1 ? '──' : index == items.length - 1 ? '└─' : index == 0 && !firstParent ? '┌─' : '├─') + ' %' + item + '%`');
   });
 }
 


### PR DESCRIPTION
I just tested the new watch option in a project where the entrypoint
is in a subdirectory (app/app.js) and files changed were not detected
when running the command
> jspm bundle app/app.js dev-bundle.js --watch

By using the cwd, this now works as expected