### PR TITLE
Use Facebook watchman for better compatibility. Especially BSD's

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -271,7 +271,7 @@ function buildWatch(files, fn) {
     return file.substr(lowestDir.length + 1);
   });
 
-  var watcher = sane(lowestDir, { glob: relFiles });
+  var watcher = sane(lowestDir, { glob: relFiles, watchman: true });
   watcher.on('ready', function() {
     ui.log('info', 'Watching %' + lowestDir + '% for changes...');
   });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "systemjs": "0.19.24",
     "systemjs-builder": "0.15.12",
     "traceur": "0.0.95",
-    "uglify-js": "^2.6.1"
+    "uglify-js": "^2.6.1",
+    "fb-watchman": "^1.9.0"
   },
   "registry": "npm",
   "devDependencies": {


### PR DESCRIPTION
Nodejs fs watcher (which is the default) does not work on FreeBSD Unix. Running sane in watchman mode does result in triggering rebuild.

Other options would be Chokidar which also works reliable on FreeBSD.