### PR TITLE
Fixing #1718 - watcher now watches files inlined by rollup.

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -262,9 +262,9 @@ exports.build = function(expression, fileName, opts) {
       if (!opts.watch)
         return output;
 
-      // create a watcher
-      buildWatch(output.modules.map(function(name) {
-        return output.tree[name] && output.tree[name].path;
+      // create a watcher based on all of the files in the tree (including the files that were inlined by rollup)
+      buildWatch(Object.keys(output.tree).map(function(name) {
+        return output.tree[name].path;
       }).filter(function(name) {
         return name;
       }), function(invalidated, rebuild) {


### PR DESCRIPTION
See #1718 for the explanation -- basically `output.modules` doesn't include the full list of files to watch because of rollup inlining.