### PR TITLE
Option assignment syntax

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -394,8 +394,8 @@ process.on('uncaughtException', function(err) {
         options.globalName = options['global-name'];
       }
 
-      if (options['externals']) {
-        options['externals'] = options['externals'].split(' ').map(function(item) {
+      if (options.externals) {
+        options.externals = options.externals.split(' ').map(function(item) {
           return item.trim();
         });
       }

--- a/cli.js
+++ b/cli.js
@@ -395,7 +395,7 @@ process.on('uncaughtException', function(err) {
       }
 
       if (options['externals']) {
-        options.externals = options['externals'].split(' ').map(function(item) {
+        options['externals'] = options['externals'].split(' ').map(function(item) {
           return item.trim();
         });
       }

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -249,9 +249,13 @@ exports.build = function(expression, fileName, opts) {
         throw 'Build exclusion "' + module + '" needs an external reference.\n\t\t\tEither output to a module format like %--format amd% or map the external module to an environment global ' +
             'via %--global-deps "{\'' + module + '\': \'' + camelCase(module, true) + '\'}"%';
       }
-      if (e.toString().indexOf('globalName option') != -1)
-        throw 'Build output to %' + opts.format + '% requires the global name to be set.\n\t\t\t' +
-          'Try adding %--global-name ' + camelCase((expression.substr(expression.length - 3, 3) == '.js' ? expression.substr(0, expression.length - 3) : expression).split(/ |\//)[0]) + '% or setting %--format amd%';
+      if (e.toString().indexOf('globalName option') != -1) {
+        var generatedGlobalName = camelCase((expression.substr(expression.length - 3, 3) == '.js' ? expression.substr(0, expression.length - 3) : expression).split(/ |\//)[0]);
+        ui.log('warn', 'Build output to %' + opts.format + '% requires the global name to be set.\n' +
+          'Added default %--global-name ' + generatedGlobalName + '% option.\n');
+        opts.globalName = generatedGlobalName;
+        return build();
+      }
       else
         throw e;
     })

--- a/lib/cli-utils.js
+++ b/lib/cli-utils.js
@@ -1,0 +1,120 @@
+exports.readOptions = readOptions;
+exports.readValue = readValue;
+exports.readPropertySetters = readPropertySetters;
+
+// takes commandline args, space-separated
+// flags is array of flag names
+// optFlags is array of flags that have option values
+// optFlags suck up arguments until next flag
+// returns { [flag]: true / false, ..., [optFlag]: value, ..., args: [all non-flag args] }
+function readOptions(inArgs, flags, optFlags) {
+  // output options object
+  var options = { args: [] };
+
+  flags = flags || [];
+  optFlags = optFlags || [];
+
+  var curOptionFlag;
+
+  function getFlagMatch(arg, flags) {
+    var index;
+
+    if (arg.startsWith('--')) {
+      index = flags.indexOf(arg.substr(2));
+      if (index !== -1)
+        return flags[index];
+    }
+    else if (arg.startsWith('-')) {
+      return flags.filter(function(f) {
+        return f.substr(0, 1) === arg.substr(1, 1);
+      })[0];
+    }
+  }
+
+  // de-sugar any coupled single-letter flags
+  // -abc -> -a -b -c
+  var args = [];
+  inArgs.forEach(function(arg) {
+    if (arg[0] == '-' && arg.length > 1 && arg[1] != '-') {
+      for (var i = 1; i < arg.length; i++)
+        args.push('-' + arg[i]);
+    }
+    else {
+      args.push(arg);
+    }
+  });
+
+  args.forEach(function(arg) {
+    var flag = getFlagMatch(arg, flags);
+    var optFlag = getFlagMatch(arg, optFlags);
+
+    // option flag -> suck up args
+    if (optFlag) {
+      curOptionFlag = optFlag;
+      options[curOptionFlag] = [];
+    }
+    // normal boolean flag
+    else if (flag) {
+      options[flag] = true;
+    }
+    // value argument
+    else {
+      if (curOptionFlag)
+        options[curOptionFlag].push(arg);
+      else
+        options.args.push(arg);
+    }
+  });
+
+  // flag values are strings
+  optFlags.forEach(function(flag) {
+    if (options[flag])
+      options[flag] = options[flag].join(' ');
+  });
+
+  return options;
+}
+
+// this will get a value in its true type from the CLI
+function readValue(val) {
+  val = val.trim();
+  if (val === 'true' || val === 'false')
+    return eval(val);
+  else if (parseInt(val).toString() == val)
+    return parseInt(val);
+  else if (val[0] == '{' && val[val.length - 1] == '}')
+    return eval('(' + val + ')');
+  else
+    return val;
+}
+
+function readPropertySetters(str) {
+  var outObj = {};
+
+  function setProperty(target, p, value) {
+    var pParts = p.split('.');
+    var curPart;
+    while (pParts.length > 1) {
+      curPart = pParts.shift();
+      target = target[curPart] = target[curPart] || {};
+    }
+    curPart = pParts.shift();
+    if (!(curPart in target))
+      target[curPart] = value;
+  }
+
+  var parts = str.split('=');
+  var lastProp;
+  parts.forEach(function(part, index) {
+    if (!lastProp) {
+      lastProp = part;
+      return;
+    }
+
+    var value = readValue(index == parts.length - 1 ? part : part.substr(0, part.lastIndexOf(' ')));
+    setProperty(outObj, lastProp, value);
+    lastProp = part.substr(part.lastIndexOf(' ') + 1).trim();
+  });
+
+  return outObj;
+}

--- a/test/cli-utils.js
+++ b/test/cli-utils.js
@@ -1,0 +1,17 @@
+var readPropertySetters = require('../lib/cli-utils').readPropertySetters;
+
+suite('CLI Utils', function() {
+  test('Simple property setters', function() {
+    var outObj = readPropertySetters('asdf.asdf=3 p=1 test=false with spa cing');
+    assert(outObj.asdf.asdf === 3);
+    assert(outObj.p === 1);
+    assert(outObj.test === 'false with spa cing');
+  });
+
+  test('Object syntax in setters', function() {
+    var outObj = readPropertySetters('a=spaced thing  b={an:"object",thing:false}');
+    assert(outObj.a === 'spaced thing');
+    assert(outObj.b.an === 'object');
+    assert(outObj.b.thing === false);
+  });
+});


### PR DESCRIPTION
This PR provides support for `jspm install lib -o directories.lib=asdf dependencies.jquery=*` style override syntax, and all other object flags.

This also includes support for an `--externals` flag which is passed to SystemJS Builder (effectively equivalent to `jspm build x --config meta.external.build=false`).

Finally, when using global deps (`jspm build test.js --global-deps jquery=$`), these are now automatically treated as externals.

Together, these give much nicer workflows around builds and installs.