### PR TITLE
Close watcher immediatly

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -314,10 +314,8 @@ function buildWatch(files, fn) {
   watcher.on('add', function(filepath) {
     var file = path.join(lowestDir, filepath);
     ui.log('ok', 'File `' + file + '` created, rebuilding...');
-    fn(file, true)
-    .then(function() {
-      watcher.close();
-    });
+    fn(file, true);
+    watcher.close();
   });
   watcher.on('delete', function(filepath) {
     var file = path.join(lowestDir, filepath);

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -316,7 +316,6 @@ function buildWatch(files, fn) {
     var file = path.join(lowestDir, filepath);
     ui.log('ok', 'File `' + file + '` created, rebuilding...');
     fn(file, true);
-    watcher.close();
   });
   watcher.on('delete', function(filepath) {
     var file = path.join(lowestDir, filepath);
@@ -327,7 +326,6 @@ function buildWatch(files, fn) {
     var file = path.join(lowestDir, filepath);
     ui.log('ok', 'File `' + file + '` changed, rebuilding...');
     fn(file, true);
-    watcher.close();
   });
 }
 

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -327,10 +327,8 @@ function buildWatch(files, fn) {
   watcher.on('change', function(filepath) {
     var file = path.join(lowestDir, filepath);
     ui.log('ok', 'File `' + file + '` changed, rebuilding...');
-    fn(file, true)
-    .then(function() {
-      watcher.close();
-    });
+    fn(file, true);
+    watcher.close();
   });
 }
 

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -172,28 +172,29 @@ exports.bundle = function(moduleExpression, fileName, opts) {
     .catch(function(e) {
       ui.log('err', e.stack || e);
       throw e;
-    })
-    .then(function(output) {
-      if (!opts.watch)
-        return output;
-
-      // create a watcher
-      buildWatch(output.modules.map(function(name) {
-        return output.tree[name] && output.tree[name].path;
-      }).filter(function(name) {
-        return name;
-      }).map(function(file) {
-        return path.resolve(config.pjson.baseURL, file);
-      }), function(invalidated, rebuild) {
-        if (invalidated)
-          systemBuilder.invalidate(toFileURL(invalidated));
-        if (rebuild)
-          return bundle();
-      });
     });
   }
 
-  return bundle();
+  return bundle()
+  .then(function(output) {
+    if (!opts.watch)
+      return output;
+
+    // create a watcher only once
+    buildWatch(output.modules.map(function(name) {
+      return output.tree[name] && output.tree[name].path;
+    }).filter(function(name) {
+      return name;
+    }).map(function(file) {
+      return path.resolve(config.pjson.baseURL, file);
+    }), function(invalidated, rebuild) {
+      if (invalidated)
+        systemBuilder.invalidate(toFileURL(invalidated));
+      if (rebuild)
+        return bundle();
+    });
+
+  });
 };
 
 exports.unbundle = function() {
@@ -258,26 +259,26 @@ exports.build = function(expression, fileName, opts) {
     .catch(function(e) {
       ui.log('err', e.stack || e);
       throw e;
-    })
-    .then(function(output) {
-      if (!opts.watch)
-        return output;
-
-      // create a watcher
-      buildWatch(output.modules.map(function(name) {
-        return output.tree[name] && output.tree[name].path;
-      }).filter(function(name) {
-        return name;
-      }), function(invalidated, rebuild) {
-        if (invalidated)
-          systemBuilder.invalidate(invalidated);
-        if (rebuild)
-          return build();
-      });
     });
   }
 
-  return build();
+  return build()
+  .then(function(output) {
+    if (!opts.watch)
+      return output;
+
+    // create a watcher
+    buildWatch(output.modules.map(function(name) {
+      return output.tree[name] && output.tree[name].path;
+    }).filter(function(name) {
+      return name;
+    }), function(invalidated, rebuild) {
+      if (invalidated)
+        systemBuilder.invalidate(invalidated);
+      if (rebuild)
+        return build();
+    });
+  });
 };
 
 var watchman = true;


### PR DESCRIPTION
When the file changes quickly, the callback function is executed more than once if the build time is too long. 

So the watcher is added multiple times, because he's closed after the build.

It just need to close it immediately for avoid multiple call.