### PR TITLE
File watching: Use sort to select the lowest directory for `buildWatch`

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -285,11 +285,10 @@ function buildWatch(files, fn) {
   var sane = require('sane');
 
   // get the lowest directory from the files listing
-  var lowestDir = path.dirname(files[0]);
-  files.forEach(function(file) {
-    if (path.dirname(file).length < lowestDir.length)
-      lowestDir = path.dirname(file);
-  });
+  files.sort(function(f1,f2){
+    return path.dirname(f1).length -  path.dirname(f2).length
+  })
+  var lowestDir = path.dirname(files[0])
 
   var relFiles = files.map(function(file) {
     if (lowestDir == '.')

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -285,10 +285,11 @@ function buildWatch(files, fn) {
   var sane = require('sane');
 
   // get the lowest directory from the files listing
-  files.sort(function(f1,f2){
-    return path.dirname(f1).length -  path.dirname(f2).length;
-  });
   var lowestDir = path.dirname(files[0]);
+  files.forEach(function(file) {
+    if (path.dirname(file).split('/').length < lowestDir.split('/').length)
+      lowestDir = path.dirname(file);
+  });
 
   var relFiles = files.map(function(file) {
     if (lowestDir == '.')

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -286,9 +286,9 @@ function buildWatch(files, fn) {
 
   // get the lowest directory from the files listing
   files.sort(function(f1,f2){
-    return path.dirname(f1).length -  path.dirname(f2).length
-  })
-  var lowestDir = path.dirname(files[0])
+    return path.dirname(f1).length -  path.dirname(f2).length;
+  });
+  var lowestDir = path.dirname(files[0]);
 
   var relFiles = files.map(function(file) {
     if (lowestDir == '.')


### PR DESCRIPTION
### File watching: Use sort to select the lowest directory for `buildWatch`

Really cool to see the new file watching in `0.17` @guybedford , excellent job on this lib.

Small fix: I noticed that the `buildWatch` fn sometimes selects the lowest directory incorrectly.  It now loops through the entire module tree and as a result some `jspm_packages` can resolve as "lower" than the main application code.  Sorting the files by their length first  then selecting the shortest directory seems to fix it. 

LMK what you think. Happy to help debug/test further. 

