### PR TITLE
Correct the warning message for `build` timeouts

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -166,7 +166,7 @@ exports.load = function(registry) {
                (typeof args[0] === 'string' ? ' for `' + registry + ':' + args[0] + '`' : '') +
                (retry ? ', retrying (' + retries + ').' : '') +
 
-               (!err ? '\nTo increase the timeout run %jspm config registries.' + registry + '.timeouts.' + (hook == 'download' ? hook : 'lookup') + ' ' + timeout / 1000 * 2 + '%' : '') +
+               (!err ? '\nTo increase the timeout run %jspm config registries.' + registry + '.timeouts.' + (hook == 'download' || hook == 'build' ? hook : 'lookup') + ' ' + timeout / 1000 * 2 + '%' : '') +
                (err ? '\n' + (!err.hideStack && err.stack || err) : '');
             ui.log('warn', msg);
             if (retry)


### PR DESCRIPTION
If a timeout occurs during the build, the warning message incorrectly directs the user to increase the `lookup` timeout:

    warn Timed out on build
         To increase the timeout run jspm config registries.npm.timeouts.lookup 240

This commit corrects the message to show the `registries.npm.timeouts.build` property instead.
