### PR TITLE
chore(appveyor): test cli on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,29 @@
+version: "{build}"
+clone_depth: 1
+environment:
+  matrix:
+    - nodejs_version: "0"
+    - nodejs_version: "1"
+    - nodejs_version: "2"
+    - nodejs_version: "3"
+    - nodejs_version: "4"
+    - nodejs_version: "5"
+    - nodejs_version: "6"
+    - nodejs_version: "stable"
+matrix:
+  fast_finish: true
+cache:
+  - node_modules
+platform:
+  - x86
+  - x64
+install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+
+  - npm config set spin false
+  - npm install
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+build: off


### PR DESCRIPTION
Hi @guybedford 

Going through the [the lastest npm version changelog](https://github.com/npm/npm/releases/tag/v3.9.0), I discovered [AppVeyor](https://ci.appveyor.com).
It's yet another CI but this one is running on Windows :rabbit: 

So I made a [little study](https://github.com/douglasduteil/study-test-es6-universal-lib/pull/1) to propose testing the jspm CLI on a native Windows environnement.

Because Windows users need some love too ;)