### PR TITLE
docs(README): add app veyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 jspm CLI
 ===
 
-[![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jspm/jspm?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Support](https://supporterhq.com/api/b/33df4abbec4d39260f49015d2457eafe/JSPM)](https://supporterhq.com/support/33df4abbec4d39260f49015d2457eafe/JSPM)
+[![NPM version][npm-image]][npm-url]
+[![Downloads][downloads-image]][npm-url]
+[![Build Status][travis-image]][travis-url]
+[![Gitter][gitter-image]][gitter-url]
+[![Support][supporterhq-image]][supporterhq-url]
 
 Registry and format agnostic JavaScript package manager.
 
@@ -41,8 +45,12 @@ See the [SystemJS](https://github.com/systemjs/systemjs) project page for System
 
 Apache 2.0
 
-[travis-url]: https://travis-ci.org/jspm/jspm-cli
-[travis-image]: https://travis-ci.org/jspm/jspm-cli.svg?branch=master
 [downloads-image]: http://img.shields.io/npm/dm/jspm.svg
-[npm-url]: https://npmjs.org/package/jspm
+[gitter-image]: https://badges.gitter.im/Join%20Chat.svg
+[gitter-url]: https://gitter.im/jspm/jspm?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 [npm-image]: http://img.shields.io/npm/v/jspm.svg
+[npm-url]: https://npmjs.org/package/jspm
+[supporterhq-image]: https://supporterhq.com/api/b/33df4abbec4d39260f49015d2457eafe/JSPM
+[supporterhq-url]: https://supporterhq.com/support/33df4abbec4d39260f49015d2457eafe/JSPM
+[travis-image]: https://travis-ci.org/jspm/jspm-cli.svg?branch=master
+[travis-url]: https://travis-ci.org/jspm/jspm-cli

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ jspm CLI
 
 [![NPM version][npm-image]][npm-url]
 [![Downloads][downloads-image]][npm-url]
-[![Build Status][travis-image]][travis-url]
+[![Travis build Status][travis-image]][travis-url]
+[![AppVeyor build Status][appveyor-image]][appveyor-url]
 [![Gitter][gitter-image]][gitter-url]
 [![Support][supporterhq-image]][supporterhq-url]
 
@@ -45,6 +46,8 @@ See the [SystemJS](https://github.com/systemjs/systemjs) project page for System
 
 Apache 2.0
 
+[appveyor-url]: https://ci.appveyor.com/project/guybedford/jspm-cli
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/XXXXXXXXXXXXXXXX/branch/master?svg=true
 [downloads-image]: http://img.shields.io/npm/dm/jspm.svg
 [gitter-image]: https://badges.gitter.im/Join%20Chat.svg
 [gitter-url]: https://gitter.im/jspm/jspm?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge


### PR DESCRIPTION
Following #1801 

This PR is adding the AppVeyor badge. 

I spotted that you created the job with your @guybedford  account so you will find the badge id here : https://ci.appveyor.com/project/guybedford/jspm-cli/settings/badges

However it might be better to use the @jspm github org account for this.