### PR TITLE
test(appveyor): temporarily allow all job to fail

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,12 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "6"
 matrix:
-  fast_finish: true
+  # Temporarily allow all test to fail until we resolve them.
+  # fast_finish: true
+  allow_failures:
+    - nodejs_version: "0"
+    - nodejs_version: "4"
+    - nodejs_version: "6"
 cache:
   - node_modules
 platform:


### PR DESCRIPTION
Following #1801

Temporally allow all test to fail on Windows until we resolve them.
Seems like the tests on Windows are failing. So I'm proposing to use them as information to make fixes.
They shouldn't block over PRs.