### PR TITLE
[0.17.0-beta-17] Fixed typescipt support for `jspm init` (fixes #1859)

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -790,7 +790,7 @@ function initPrompts(newProject) {
     var curTranspiler = loader.transpiler;
 
     // default transpiler will be typescript only if the main loader file ends with .ts
-    var defTranspiler = /(?:\.([^.]+))?$/.exec(loader.package.main)[1] === 'ts' ? 'typescript' : 'babel';
+    var defTranspiler = /\.ts$/.test(loader.package.main) ? 'typescript' : 'babel';
 
     if (curTranspiler && (curTranspiler.substr(0, 7) == 'plugin-' || curTranspiler.substr(0, 7) == 'loader-') && 
         transpilers.indexOf(curTranspiler.substr(7).toLowerCase()) != -1)

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -789,13 +789,16 @@ function initPrompts(newProject) {
 
     var curTranspiler = loader.transpiler;
 
+    // default transpiler will be typescript only if the main loader file ends with .ts
+    var defTranspiler = /(?:\.([^.]+))?$/.exec(loader.package.main)[1] === 'ts' ? 'typescript' : 'babel';
+
     if (curTranspiler && (curTranspiler.substr(0, 7) == 'plugin-' || curTranspiler.substr(0, 7) == 'loader-') && 
         transpilers.indexOf(curTranspiler.substr(7).toLowerCase()) != -1)
       curTranspiler = curTranspiler.substr(7).toLowerCase();
     else if (curTranspiler)
       transpilers.push(curTranspiler);
 
-    return ui.input('%SystemJS.config transpiler (Babel, Traceur, TypeScript, None)%', curTranspiler || 'babel', {
+    return ui.input('%SystemJS.config transpiler (Babel, Traceur, TypeScript, None)%', curTranspiler || defTranspiler, {
       info: 'Select a transpiler to use for ES module conversion.\n\n' +
           'The transpiler is used when detecting modules with %import% or %export% statements, or ' +
           'for modules with %format: "esm"% metadata set.',
@@ -812,9 +815,10 @@ function initPrompts(newProject) {
       // set transpiler on BOTH the transpiler and local package loader config
       if (loader.package) {
         var pkgMeta = loader.package.meta = loader.package.meta || {};
-        pkgMeta['*.js'] = pkgMeta['*.js'] || {};
-        if (!pkgMeta['*.js'].loader || pkgMeta['*.js'].loader == loader.transpiler)
-          pkgMeta['*.js'].loader = pkgMeta['*.js'].loader || 'plugin-' + transpiler.toLowerCase();
+        var pkgExt = transpiler === 'typescript' ? '*.ts' : '*.js';
+        pkgMeta[pkgExt] = pkgMeta[pkgExt] || {};
+        if (!pkgMeta[pkgExt].loader || pkgMeta[pkgExt].loader == loader.transpiler)
+          pkgMeta[pkgExt].loader = pkgMeta[pkgExt].loader || 'plugin-' + transpiler.toLowerCase();
       }
       loader.transpiler = 'plugin-' + transpiler.toLowerCase();
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -790,7 +790,7 @@ function initPrompts(newProject) {
     var curTranspiler = loader.transpiler;
 
     // default transpiler will be typescript only if the main loader file ends with .ts
-    var defTranspiler = /\.ts$/.test(loader.package.main) ? 'typescript' : 'babel';
+    var defTranspiler = /\.ts$/.test(loader.package && loader.package.main) ? 'typescript' : 'babel';
 
     if (curTranspiler && (curTranspiler.substr(0, 7) == 'plugin-' || curTranspiler.substr(0, 7) == 'loader-') && 
         transpilers.indexOf(curTranspiler.substr(7).toLowerCase()) != -1)


### PR DESCRIPTION
- fixed the initialization of typescript projects by loading .ts files into plugin-typescipt instead of *.js files. This eventually resulted in the `err  Source StudioDashboard/App.js has multiple anonymous System.register calls.` error when trying to bundle or build (fixes #1859).

- If the user inputs a typescipt file for the main entry point the 'Select a transpiler' step will default to 'typescript' instead of 'babel'

Note: I tried to match your coding style, making it as terse as possible. Tell me if there is anything wrong with it. Thanks!