### PR TITLE
`--watch` deals with the configuration changing.

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -150,9 +150,7 @@ exports.bundle = function(moduleExpression, fileName, opts) {
   opts = opts || {};
   fileName = fileName || path.resolve(config.pjson.baseURL, 'build.js');
 
-  function bundle(builder) {
-    var latestBuilder = builder || systemBuilder;
-
+  function bundle(givenBuilder) {
     return Promise.resolve()
     .then(function() {
       if (!opts.sourceMaps)
@@ -161,7 +159,7 @@ exports.bundle = function(moduleExpression, fileName, opts) {
     .then(function() {
       ui.log('info', 'Building the bundle tree for %' + moduleExpression + '%...');
 
-      return latestBuilder.bundle(moduleExpression, fileName, opts);
+      return givenBuilder.bundle(moduleExpression, fileName, opts);
     })
     .then(function(output) {
       logTree(output.modules);
@@ -178,7 +176,7 @@ exports.bundle = function(moduleExpression, fileName, opts) {
     });
   }
 
-  return bundle()
+  return bundle(systemBuilder)
   .then(function(output) {
     if (!opts.watch)
       return output;
@@ -221,9 +219,7 @@ exports.build = function(expression, fileName, opts) {
   opts = opts || {};
   fileName = fileName || path.resolve(config.pjson.baseURL, 'build.js');
 
-  function build(newBuilder) {
-    var latestBuilder = newBuilder || systemBuilder;
-
+  function build(givenBuilder) {
     return Promise.resolve()
     .then(function() {
       if (!opts.sourceMaps)
@@ -232,7 +228,7 @@ exports.build = function(expression, fileName, opts) {
     .then(function() {
       ui.log('info', 'Creating the single-file build for %' + expression + '%...');
 
-      return latestBuilder.buildStatic(expression, fileName, opts);
+      return givenBuilder.buildStatic(expression, fileName, opts);
     })
     .then(function(output) {
       logTree(output.modules, output.inlineMap ? output.inlineMap : opts.rollup);
@@ -253,14 +249,14 @@ exports.build = function(expression, fileName, opts) {
         ui.log('warn', 'Build output to %' + opts.format + '% requires the global name to be set.\n' +
           'Added default %--global-name ' + generatedGlobalName + '% option.\n');
         opts.globalName = generatedGlobalName;
-        return build();
+        return build(systemBuilder);
       }
       else
         throw e;
     });
   }
 
-  return build()
+  return build(systemBuilder)
   .then(function(output) {
     if (!opts.watch)
       return output;
@@ -395,6 +391,7 @@ function buildWatch(builder, output, build) {
       if (changeWasConfigFile) {
         config.loader = new JspmSystemConfig(config.pjson.configFile);
         builder = new Builder();
+        return;
       }
 
       if (file) {
@@ -415,21 +412,12 @@ function buildWatch(builder, output, build) {
       else
         ui.log('ok', 'File changes made during previous build, rebuilding...');
 
-      var buildPromise;
-      if (changeWasConfigFile) {
-        // don't bother doing a rebuild for a config file change
-        // but just keep watching so the next time a file changes
-        // the bundle is rebuilt but with the new Builder & config
-        buildPromise = buildWatch(builder, output, build);
-      } else {
-        buildPromise = build(builder).then(function(output) {
-          return buildWatch(builder, output, build);
-        }, function(err) {
-          ui.log('err', err.stack || err);
-          return buildWatch(builder, output, build);
-        });
-      }
-      return buildPromise.then(function(newWatcherRefresh) {
+      return build(builder).then(function(output) {
+        return buildWatch(builder, output, build);
+      }, function(err) {
+        ui.log('err', err.stack || err);
+        return buildWatch(builder, output, build);
+      }).then(function(newWatcherRefresh) {
         unwatch();
         if (rebuild)
           newWatcherRefresh();

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -21,6 +21,7 @@ var fs = require('fs');
 var asp = require('bluebird').Promise.promisify;
 var extendSystemConfig = require('./common').extendSystemConfig;
 var toFileURL = require('./common').toFileURL;
+var JspmSystemConfig = require('./config/loader').JspmSystemConfig;
 
 function camelCase(name, capitalizeFirst) {
   return name.split('-').map(function(part, index) {
@@ -149,7 +150,9 @@ exports.bundle = function(moduleExpression, fileName, opts) {
   opts = opts || {};
   fileName = fileName || path.resolve(config.pjson.baseURL, 'build.js');
 
-  function bundle() {
+  function bundle(builder) {
+    var latestBuilder = builder || systemBuilder;
+
     return Promise.resolve()
     .then(function() {
       if (!opts.sourceMaps)
@@ -158,7 +161,7 @@ exports.bundle = function(moduleExpression, fileName, opts) {
     .then(function() {
       ui.log('info', 'Building the bundle tree for %' + moduleExpression + '%...');
 
-      return systemBuilder.bundle(moduleExpression, fileName, opts);
+      return latestBuilder.bundle(moduleExpression, fileName, opts);
     })
     .then(function(output) {
       logTree(output.modules);
@@ -218,7 +221,9 @@ exports.build = function(expression, fileName, opts) {
   opts = opts || {};
   fileName = fileName || path.resolve(config.pjson.baseURL, 'build.js');
 
-  function build() {
+  function build(newBuilder) {
+    var latestBuilder = newBuilder || systemBuilder;
+
     return Promise.resolve()
     .then(function() {
       if (!opts.sourceMaps)
@@ -227,7 +232,7 @@ exports.build = function(expression, fileName, opts) {
     .then(function() {
       ui.log('info', 'Creating the single-file build for %' + expression + '%...');
 
-      return systemBuilder.buildStatic(expression, fileName, opts);
+      return latestBuilder.buildStatic(expression, fileName, opts);
     })
     .then(function(output) {
       logTree(output.modules, output.inlineMap ? output.inlineMap : opts.rollup);
@@ -299,7 +304,7 @@ function createWatcher(files, opts) {
 
   var watcher;
   // share the existing watcher if possible
-  if (watchman && lowestDir != watchDir || 
+  if (watchman && lowestDir != watchDir ||
       !watchman && (lowestDir != watchDir || JSON.stringify(watchFiles) != JSON.stringify(relFiles))) {
     var sane = require('sane');
     if (curWatcher)
@@ -360,6 +365,12 @@ function buildWatch(builder, output, build) {
       return path.resolve(config.pjson.baseURL, file);
     });
 
+    var configFiles = [config.pjson.configFile];
+    if (config.pjson.configFileBrowser) configFiles.push(config.pjson.configFileBrowser);
+    if (config.pjson.configFileDev) configFiles.push(config.pjson.configFileDev);
+
+    files = files.concat(configFiles);
+
     var unwatch = createWatcher(files, {
       ready: function(dir, watchman) {
         ui.log('info', 'Watching %' + (path.relative(process.cwd(), dir) || '.') + '% for changes ' + (watchman ? 'with Watchman' : 'with Node native watcher') + '...');
@@ -377,7 +388,15 @@ function buildWatch(builder, output, build) {
 
     var building = false;
     var rebuild = false;
+    var changeWasConfigFile = false;
     function changed(file) {
+      changeWasConfigFile = ( configFiles.indexOf(file) > -1 );
+
+      if (changeWasConfigFile) {
+        config.loader = new JspmSystemConfig(config.pjson.configFile);
+        builder = new Builder();
+      }
+
       if (file) {
         builder.invalidate(toFileURL(file));
         // also invalidate any plugin syntax cases
@@ -391,17 +410,26 @@ function buildWatch(builder, output, build) {
 
       building = true;
       rebuild = false;
-      if (file) 
+      if (file)
         ui.log('ok', 'File `' + path.relative(process.cwd(), file) + '` changed, rebuilding...');
       else
         ui.log('ok', 'File changes made during previous build, rebuilding...');
-      build().then(function(output) {
-        return buildWatch(builder, output, build);
-      }, function(err) {
-        ui.log('err', err.stack || err);
-        return buildWatch(builder, output, build);
-      })
-      .then(function(newWatcherRefresh) {
+
+      var buildPromise;
+      if (changeWasConfigFile) {
+        // don't bother doing a rebuild for a config file change
+        // but just keep watching so the next time a file changes
+        // the bundle is rebuilt but with the new Builder & config
+        buildPromise = buildWatch(builder, output, build);
+      } else {
+        buildPromise = build(builder).then(function(output) {
+          return buildWatch(builder, output, build);
+        }, function(err) {
+          ui.log('err', err.stack || err);
+          return buildWatch(builder, output, build);
+        });
+      }
+      return buildPromise.then(function(newWatcherRefresh) {
         unwatch();
         if (rebuild)
           newWatcherRefresh();

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -145,8 +145,6 @@ exports.depCache = function(expression) {
 
 // options.inject, options.sourceMaps, options.minify
 exports.bundle = function(moduleExpression, fileName, opts) {
-  var systemBuilder = new Builder();
-
   opts = opts || {};
   fileName = fileName || path.resolve(config.pjson.baseURL, 'build.js');
 
@@ -176,6 +174,7 @@ exports.bundle = function(moduleExpression, fileName, opts) {
     });
   }
 
+  var systemBuilder = new Builder();
   return bundle(systemBuilder)
   .then(function(output) {
     if (!opts.watch)
@@ -214,8 +213,6 @@ function logBuild(outFile, opts) {
 
 // options.minify, options.sourceMaps
 exports.build = function(expression, fileName, opts) {
-  var systemBuilder = new Builder();
-
   opts = opts || {};
   fileName = fileName || path.resolve(config.pjson.baseURL, 'build.js');
 
@@ -249,13 +246,14 @@ exports.build = function(expression, fileName, opts) {
         ui.log('warn', 'Build output to %' + opts.format + '% requires the global name to be set.\n' +
           'Added default %--global-name ' + generatedGlobalName + '% option.\n');
         opts.globalName = generatedGlobalName;
-        return build(systemBuilder);
+        return build(givenBuilder);
       }
       else
         throw e;
     });
   }
 
+  var systemBuilder = new Builder();
   return build(systemBuilder)
   .then(function(output) {
     if (!opts.watch)


### PR DESCRIPTION
This change means you can install a package and not have your watch task
bail on you.

My thoughts here are to keep an eye out for when the config file changes (when you do an install for example) and then refresh the builder instance such that it loads the new config in.

However doing so in the manner I've got in the code leads to the `bundle` failing with:

```
err  Error: Configuration file jspm.config.js has been modified by another process.
```

Which I completely understand. I'm not sure then if this is straightforward as I think, or if actually I'm just going about it in the whole way - my lack of knowledge of the internals of SystemJS Builder might be holding me back.

@guybedford have you any thoughts?