### PR TITLE
inspect: multiple versions detail

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -76,7 +76,7 @@ process.on('uncaughtException', function(err) {
       + 'jspm uninstall name                Uninstall a package and clean dependencies\n'
       + 'jspm clean                         Clear unused and orphaned dependencies\n'
       + '\n'
-      + 'jspm inspect [--forks]             View all installed package versions\n'
+      + 'jspm inspect [--forks] [--multiple] View all installed package versions\n'
       + 'jspm inspect npm:source-map        View the versions and ranges of a package\n'
       + '\n'
       + 'jspm inject <name[=target]> [--force] [--latest] [--lock] [-o]\n'
@@ -374,13 +374,13 @@ process.on('uncaughtException', function(err) {
       break;
 
     case 'inspect':
-      options = readOptions(args, ['forks']);
+      options = readOptions(args, ['forks', 'multiple']);
       args = options.args;
 
       config.load()
       .then(function() {
         if (!args[1])
-          return install.showVersions(options.forks);
+          return install.showVersions(options.forks, options.multiple);
         if (!args[1].includes(':'))
           return ui.log('warn', 'Enter a full package name of the format `registry:repo`.');
         return install.showInstallGraph(args[1]);

--- a/lib/install.js
+++ b/lib/install.js
@@ -15,6 +15,7 @@
  */
 
 require('core-js/es6/string');
+require('core-js/fn/array/find');
 
 var config = require('./config');
 var Promise = require('rsvp').Promise;
@@ -776,14 +777,14 @@ function showInstallGraph(pkg) {
 exports.showInstallGraph = showInstallGraph;
 
 
-function showVersions(forks) {
+function showVersions(forks, multiple) {
   installed = installed || config.loader;
 
   var versions = {};
   var haveLinked = false;
   var linkedVersions = {};
 
-  function addDep(dep) {
+  function addDep(dep, parent) {
     var vList = versions[dep.name] = versions[dep.name] || [];
     var version = dep.version;
     try {
@@ -791,8 +792,21 @@ function showVersions(forks) {
         linkedVersions[dep.exactName] = true;
     }
     catch(e) {}
-    if (vList.indexOf(version) === -1)
-      vList.push(version);
+    var found = vList.find(function(vItem) {
+      return vItem.number == version;
+    });
+    if (!found) {
+      var vItem = {
+        number: version,
+        parents: []
+      };
+      if (parent) {
+        vItem.parents.push(parent);
+      }
+      vList.push(vItem);
+    } else if (found.parents.indexOf(parent) !== -1) {
+      found.parents.push(parent);
+    }
   }
 
   Object.keys(installed.baseMap).forEach(function(dep) {
@@ -801,11 +815,18 @@ function showVersions(forks) {
   Object.keys(installed.depMap).forEach(function(parent) {
     var curMap = installed.depMap[parent];
     Object.keys(curMap).forEach(function(dep) {
-      addDep(curMap[dep]);
+      addDep(curMap[dep], parent);
     });
   });
 
   versions = alphabetize(versions);
+  if (multiple) {
+    Object.keys(versions).forEach(function(version) {
+      if (versions[version].length < 2) {
+        delete versions[version];
+      }
+    });
+  }
 
   var vLen = Object.keys(versions).map(function(dep) {
     return dep.length;
@@ -816,13 +837,21 @@ function showVersions(forks) {
   var shownIntro = false;
 
   Object.keys(versions).forEach(function(dep) {
-    var vList = versions[dep].sort(semver.compare).map(function(version) {
-      if (linkedVersions[dep + '@' + version]) {
+    var vList = versions[dep].sort(function(v1, v2) {
+      return semver.compare(v1.number, v2.number);
+    }).map(function(version) {
+      if (linkedVersions[dep + '@' + version.number]) {
         haveLinked = true;
-        return '%' + version + '%';
+        return {
+          number: '%' + version.number + '%',
+          parents: version.parents
+        };
       }
       else
-        return '`' + version + '`';
+        return {
+          number: '`' + version.number + '`',
+          parents: version.parents
+        };
     });
 
     if (forks && vList.length === 1)
@@ -838,7 +867,15 @@ function showVersions(forks) {
     while(padding--)
       paddingString += ' ';
 
-    ui.log('info', '  ' + paddingString + '%' + dep + '% ' + vList.join(' '));
+    if (multiple) {
+      vList.forEach(function(vItem) {
+        ui.log('info', '  ' + paddingString + '%' + dep + '% ' + vItem.number + ' ' + vItem.parents.join(' '));
+      });
+    } else {
+      ui.log('info', '  ' + paddingString + '%' + dep + '% ' + vList.map(function(vItem) {
+        return vItem.number;
+      }).join(' '));
+    }
   });
 
   if (haveLinked) {


### PR DESCRIPTION
By running the command `jspm inspect`, we can check if there are
multiple versions of the same dependency in the project.

This commit adds a new flag `--multiple` that allows to have more
details about these multiple versions, notably from which parent
dependency they come from.
This is super useful when trying to understand why there are
multiple versions of the same dependency in the project.

Example output

     Installed Versions

            npm:d3 3.5.17 npm:d3-heatmap@1.2.1
            npm:d3 4.1.0
       npm:isarray 0.0.1 npm:readable-stream@1.1.14
       npm:isarray 1.0.0 npm:buffer@3.6.0

We can see that there are 2 versions of d3:
* 3.5.17, which comes from the parent dependency d3-heatmap
* 4.1.0, which is a direct dependency (as it has no parent)