### PR TITLE
make jspm more square for most monospace fonts

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -46,9 +46,9 @@ process.on('uncaughtException', function(err) {
 (function() {
   function showHeader() {
     ui.log('\n'
-      + '  ' + chalk.bgWhite('      ') + '\n'
-      + '  ' + chalk.bgWhite.yellow(' jspm ') + '  ' + chalk.grey('Browser Package Management') + '\n'
-      + '  ' + chalk.bgWhite('      ') + '\n'
+      + '  ' + chalk.bgWhite('        ') + '\n'
+      + '  ' + chalk.bgWhite.yellow('  jspm  ') + '  ' + chalk.grey('Browser Package Management') + '\n'
+      + '  ' + chalk.bgWhite('        ') + '\n'
     );
   }
 


### PR DESCRIPTION
Currently the jspm icon on the help page appears oblong since most monospace fonts are designed with those proportions. This commit adapts to this most common situation (assuming a square shape is intended)
