### PR TITLE
refactor(config): Implement checksum for file integrity

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -17,6 +17,7 @@
 var path = require('path');
 var fs = require('fs');
 var mkdirp = require('mkdirp');
+var makeChecksum = require('checksum');
 
 /*
  * Configuration base class
@@ -28,12 +29,12 @@ function ConfigFile(fileName, ordering) {
   this.fileName = path.resolve(fileName);
 
   this.ordering = ordering;
-  
+
   // configuration file style is detected when loading
   this.style = null;
 
-  // we note the configuration file timestamp
-  this.timestamp = null;
+  // we note the configuration file checksum
+  this.checksum = null;
 
   // properties are stored as an ordered array of { key, value } pairs
   // nested objects are in turn array values
@@ -54,7 +55,7 @@ function configError(memberArray, msg) {
     msg = memberArray;
     memberArray = [];
   }
-  throw new TypeError('Error reading %' + path.relative(process.cwd(), this.fileName) + '%\n\t' + 
+  throw new TypeError('Error reading %' + path.relative(process.cwd(), this.fileName) + '%\n\t' +
       (memberArray.length ? '%' + memberArray.join('.') + '% ' : 'File ') + msg + '.');
 }
 
@@ -162,15 +163,15 @@ ConfigFile.prototype.rename = function(newName) {
   newName = path.resolve(newName);
   if (this.fileName == newName)
     return;
-  this.originalName = this.originalName || this.timestamp != -1 && this.fileName;
+  this.originalName = this.originalName || this.checksum != -1 && this.fileName;
   this.fileName = newName;
   try {
-    this.timestamp = fs.statSync(this.fileName).mtime.getTime();
+    this.checksum = makeChecksum(fs.readFileSync(this.fileName).toString());
   }
   catch(e) {
     if (e.code != 'ENOENT')
       throw e;
-    this.timestamp = -1;
+    this.checksum = -1;
   }
   this.changed = true;
 };
@@ -198,7 +199,7 @@ ConfigFile.prototype.getValue = function(memberArray, type) {
 
   if (type == 'array' && !(value instanceof Array) || (type && type != 'array' && typeof value != type))
     configError.call(this, memberArray, 'must be a' + (type == 'array' ? 'n ' : ' ') + type + ' value');
-  
+
   return value;
 };
 
@@ -271,16 +272,16 @@ ConfigFile.prototype.getObject = function(memberArray, nested, createIfUndefined
 
   if (!properties)
     return;
-  
+
   var obj = propertiesToObject(properties);
-  
+
   var self = this;
   if (!nested)
     Object.keys(obj).forEach(function(key) {
       if (typeof obj[key] == 'object' && obj[key] !== null && !(obj[key] instanceof Array))
         configError.call(self, memberArray, 'should not contain a nested object at %' + key + '%');
     });
-  
+
   return obj;
 };
 function propertiesToObject(properties) {
@@ -416,7 +417,7 @@ ConfigFile.prototype.orderFirst = function(memberArray) {
 
   if (!properties)
     return;
-  
+
   var propIndex = getProperty(properties, memberArray[memberArray.length - 1]).index;
 
   if (propIndex != -1 && propIndex != 0) {
@@ -432,7 +433,7 @@ ConfigFile.prototype.orderLast = function(memberArray) {
 
   if (!properties)
     return;
-  
+
   var propIndex = getProperty(properties, memberArray[memberArray.length - 1]).index;
 
   if (propIndex != -1 && propIndex != properties.length - 1) {
@@ -443,7 +444,7 @@ ConfigFile.prototype.orderLast = function(memberArray) {
 
 // only clears on empty if not already existing as empty
 // sets this.changed, retains ordering and overwrites as with setValue
-// keepOrder indicates if new properties should be added in current iteration order 
+// keepOrder indicates if new properties should be added in current iteration order
 // instead of applying the ordering algorithm
 ConfigFile.prototype.setObject = function(memberArray, obj, clearIfEmpty, keepOrder) {
   // convert object into a properties array
@@ -483,14 +484,14 @@ ConfigFile.prototype.onChange = function(memberArray) {
 ConfigFile.prototype.read = function() {
   var contents;
   try {
-    this.timestamp = fs.statSync(this.fileName).mtime.getTime();
     contents = fs.readFileSync(this.fileName).toString();
+    this.checksum = makeChecksum(contents);
   }
   catch(e) {
     if (e.code != 'ENOENT')
       throw e;
 
-    this.timestamp = -1;
+    this.checksum = -1;
     contents = '';
   }
 
@@ -509,26 +510,26 @@ ConfigFile.prototype.read = function() {
   this.changed = false;
 };
 ConfigFile.prototype.write = function() {
-  var timestamp;
+  var checksum;
   try {
-    timestamp = fs.statSync(this.fileName).mtime.getTime();
+    checksum = makeChecksum(fs.readFileSync(this.fileName).toString());
   }
   catch(e) {
     if (e.code != 'ENOENT')
       throw e;
 
-    timestamp = -1;
+    checksum = -1;
   }
 
-  if (timestamp !== this.timestamp)
+  if (checksum !== this.checksum)
     throw new Error('Configuration file ' + path.relative(process.cwd(), this.fileName) + ' has been modified by another process.');
 
-  if (this.changed || timestamp == -1) {
+  if (this.changed || checksum == -1) {
     // if the file doesn't exist make sure the folder exists
     mkdirp.sync(path.dirname(this.fileName));
     var obj = this.getObject([], true);
     fs.writeFileSync(this.fileName, this.serialize(obj));
-    this.timestamp = fs.statSync(this.fileName).mtime.getTime();
+    this.checksum = makeChecksum(fs.readFileSync(this.fileName).toString());
 
     this.changed = false;
 
@@ -568,7 +569,7 @@ function detectStyle(string) {
     if (!bestTabLength || tabDifferenceFreqs[tabLength] >= tabDifferenceFreqs[bestTabLength])
       bestTabLength = tabLength;
   });
-  // having determined the most common spacing difference length, 
+  // having determined the most common spacing difference length,
   // generate samples of this tab length from the end of each line space
   // the most common sample is then the tab string
   var tabSamples = {};
@@ -581,7 +582,7 @@ function detectStyle(string) {
     if (!bestTabSample || tabSamples[sample] > tabSamples[bestTabSample])
       bestTabSample = sample;
   });
-  
+
   if (bestTabSample)
     style.tab = bestTabSample;
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -117,14 +117,14 @@ exports.load = function(prompts, allowNoConfig) {
     if (allowNoConfig && !config.pjson.jspmAware && !config.loader.upgrade16)
       config.loader.transpiler = 'none';
 
-    if ((!process.env.jspmConfigPath || config.pjson.file.timestamp == -1) && !allowNoConfig)
+    if ((!process.env.jspmConfigPath || config.pjson.file.checksum == -1) && !allowNoConfig)
       return ui.confirm('Package.json file does not exist, create it?', true)
       .then(function(create) {
         if (!create)
           throw 'Operation aborted.';
       });
 
-    if (!allowNoConfig && config.loader.file.timestamp == -1 && !config.loader.upgrade16)
+    if (!allowNoConfig && config.loader.file.checksum == -1 && !config.loader.upgrade16)
       return ui.confirm('Configuration file %' + path.relative(process.cwd(), config.pjson.configFile) + '% does not exist, create it?', true)
       .then(function(create) {
         if (!create)
@@ -141,7 +141,7 @@ exports.load = function(prompts, allowNoConfig) {
       return;
 
     if (!config.pjson.jspmAware && !allowNoConfig || prompts)
-      return initPrompts(!process.env.jspmConfigPath || config.pjson.file.timestamp == -1 || !config.pjson.jspmAware);
+      return initPrompts(!process.env.jspmConfigPath || config.pjson.file.checksum == -1 || !config.pjson.jspmAware);
   })
   .then(function(initInstalls) {
     if (!config.loader.upgrade16 || !config.pjson.jspmAware)
@@ -149,7 +149,7 @@ exports.load = function(prompts, allowNoConfig) {
 
     if (allowNoConfig)
       throw new Error('The current project needs to be upgraded to jspm 0.17 before any further operations can run. Run %jspm init% to start the upgrade.');
-    
+
     // NB complete testing here
     return ui.confirm('jspm will now attempt to upgrade your project to the 0.17 configuration.\nAre you sure you want to proceed?', true, {
       info: 'This is an beta release of jspm 0.17, which is not yet fully stable. Make sure you have a backup of your project.'
@@ -278,7 +278,7 @@ exports.load = function(prompts, allowNoConfig) {
         return require('../install').install(true);
       })
       .then(function() {
-        // uninstall babel transpiler 
+        // uninstall babel transpiler
         if (config.loader.transpiler == 'babel') {
           ui.log('info', 'Uninstalling jspm 0.16 Babel transpiler...\n');
           return require('../install').uninstall('babel');
@@ -304,9 +304,9 @@ exports.load = function(prompts, allowNoConfig) {
       .then(function() {
         ui.log('ok', 'jspm 0.17-beta upgrade complete.\n\n' +
           'Some important breaking changes to note:\n\n' +
-          wordWrap('• The %config.js% file has been renamed to %jspm.config.js% unless you were already using a custom config path for this.\n', process.stdout.columns - 4, 2, 0, true) + '\n' + 
-          wordWrap('• js extensions are required for module imports not inside packages. Eg %System.import(\'./test\')% will need to become %System.import(\'./test.js\')%.', process.stdout.columns - 4, 2, 0, true) + '\n' + 
-          '\nThere are also other smaller breaking changes in this release, described in the full changelog at https://github.com/jspm/jspm-cli/releases/tag/0.17.0-beta.\n' + '\n' + 
+          wordWrap('• The %config.js% file has been renamed to %jspm.config.js% unless you were already using a custom config path for this.\n', process.stdout.columns - 4, 2, 0, true) + '\n' +
+          wordWrap('• js extensions are required for module imports not inside packages. Eg %System.import(\'./test\')% will need to become %System.import(\'./test.js\')%.', process.stdout.columns - 4, 2, 0, true) + '\n' +
+          '\nThere are also other smaller breaking changes in this release, described in the full changelog at https://github.com/jspm/jspm-cli/releases/tag/0.17.0-beta.\n' + '\n' +
           'Please report any issues or feedback to help improve this release and thanks for testing it out.');
       });
     });
@@ -318,7 +318,7 @@ exports.load = function(prompts, allowNoConfig) {
       return install.install(initInstalls, { dev: true })
       .then(function() {
         ui.log('info', '');
-        ui.log('ok', 'jspm init completed. For the standard project layout see _http://jspm.io/0.17-beta-guide/creating-a-project.html_.\n' + 
+        ui.log('ok', 'jspm init completed. For the standard project layout see _http://jspm.io/0.17-beta-guide/creating-a-project.html_.\n' +
             'To rerun these init prompts at any time use %jspm init%.');
       });
   });
@@ -332,9 +332,9 @@ exports.loadSync = function(allowNoConfig) {
     throw 'Configuration file is already loading.';
 
   config.allowNoConfig = !!allowNoConfig;
-  
+
   config.pjsonPath = process.env.jspmConfigPath || path.resolve(process.cwd(), 'package.json');
-  
+
   config.pjson = new PackageConfig(config.pjsonPath);
 
   if (!allowNoConfig) {
@@ -405,7 +405,7 @@ exports.save = function() {
     config.pjson.write();
     mkdirp.sync(config.pjson.packages);
     fs.writeFileSync(path.resolve(config.pjson.packages, '.dependencies.json'), getSerializedDeps(config.deps));
-  } 
+  }
 };
 
 /*
@@ -483,8 +483,8 @@ function initPrompts(newProject) {
   .then(function() {
     return ui.input('%package.json directories.baseURL%', baseURL || '.', {
       edit: true,
-      info: 'Enter the file path to the shared public folder served to the browser.\n\n' + 
-          (loader.package ? 'If omitted, %paths% locations must be individually configured between the browser and Node environments (which will then be prompted here).' : 'By default this is taken to be the root project folder.'),
+      info: 'Enter the file path to the shared public folder served to the browser.\n\n' +
+          (loader.package ? 'If ommitted, paths locations must be individually configured between the browser and Node environments (which will then be prompted here).' : 'By default this is taken to be the root project folder.'),
       validate: function(baseURL) {
         if (path.resolve(baseURL) != base && !inDir(path.resolve(baseURL), base))
           return 'The directories.baseURL path should be a subfolder within the project.';
@@ -551,7 +551,7 @@ function initPrompts(newProject) {
   // create a separate jspm.dev.js file?
   .then(function() {
     return ui.confirm('%Use package.json configFiles.jspm:dev?%', !!loader.devFile, {
-      info: 'Use a separate %jspm.dev.js% config file?\n\n' + 
+      info: 'Use a separate %jspm.dev.js% config file?\n\n' +
           'This would be used for all %--dev% install configuration.'
     })
     .then(function(useDev) {
@@ -584,7 +584,7 @@ function initPrompts(newProject) {
       return;
 
     return ui.confirm('%Use package.json configFiles.jspm:browser?%', !!loader.browserFile, {
-      info: 'Use a separate %jspm.browser.js% config file?\n\n' + 
+      info: 'Use a separate %jspm.browser.js% config file?\n\n' +
           'This would be used for browser paths and bundle configuration.'
     })
     .then(function(useBrowser) {
@@ -615,7 +615,7 @@ function initPrompts(newProject) {
       return;
 
     return ui.confirm('%Use package.json configFiles.jspm:node?%', !!loader.nodeFile, {
-      info: 'Use a separate %jspm.node.js% config file?\n\n' + 
+      info: 'Use a separate %jspm.node.js% config file?\n\n' +
           'This would be used for all %--node% install configuration.'
     })
     .then(function(useNode) {
@@ -792,7 +792,7 @@ function initPrompts(newProject) {
     // default transpiler will be typescript only if the main loader file ends with .ts
     var defTranspiler = /\.ts$/.test(loader.package && loader.package.main) ? 'typescript' : 'babel';
 
-    if (curTranspiler && (curTranspiler.substr(0, 7) == 'plugin-' || curTranspiler.substr(0, 7) == 'loader-') && 
+    if (curTranspiler && (curTranspiler.substr(0, 7) == 'plugin-' || curTranspiler.substr(0, 7) == 'loader-') &&
         transpilers.indexOf(curTranspiler.substr(7).toLowerCase()) != -1)
       curTranspiler = curTranspiler.substr(7).toLowerCase();
     else if (curTranspiler)

--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -41,7 +41,7 @@ var fs = require('fs');
  * - browserRegistryPaths
  * - browserLibURL
  * - nodeLibURL
- * 
+ *
  * Public methods:
  * - ensureRegistry(registryName)
  *
@@ -69,13 +69,13 @@ function JspmSystemConfig(fileName) {
   // if the config file is not provided in the package.json we still check for it at the default
   // location of package.json configFiles.x to see if it exists in the file system
   this.createConfigFile('dev');
-  if (this.devFile.timestamp == -1) {
+  if (this.devFile.checksum == -1) {
     this.devFile = null;
   }
   else {
     // there is some risk with this setProperties getProperties approach due to mutability
     // since it creates a binding between the objects as the getProperties aren't cloned
-    // we don't hit those cases due to the nature of this separation not being a clone, 
+    // we don't hit those cases due to the nature of this separation not being a clone,
     // and by using change event forwarding, but it needs to be noted
     if (this.file.has(['devConfig']))
       this.file.setObject(['devConfig'], extendSystemConfig(this.file.getObject(['devConfig'], true), this.devFile.getObject([], true)));
@@ -84,7 +84,7 @@ function JspmSystemConfig(fileName) {
   }
 
   this.createConfigFile('browser');
-  if (this.browserFile.timestamp == -1) {
+  if (this.browserFile.checksum == -1) {
     this.browserFile = null;
   }
   else {
@@ -95,7 +95,7 @@ function JspmSystemConfig(fileName) {
   }
 
   this.createConfigFile('node');
-  if (this.nodeFile.timestamp == -1) {
+  if (this.nodeFile.checksum == -1) {
     this.nodeFile = null;
   }
   else {
@@ -106,7 +106,7 @@ function JspmSystemConfig(fileName) {
   }
 
   this.file.changed = false;
-  
+
   // forward change events when using separate files for these objects
   this.file.changeEvents.push(function(memberArray) {
     if (['devConfig', 'browserConfig', 'nodeConfig'].indexOf(memberArray[0]) != -1) {
@@ -134,7 +134,7 @@ function JspmSystemConfig(fileName) {
     }
     self.baseMap[key] = new PackageName(map[key], true);
   });
-  
+
   (this.file.getProperties(['packages']) || []).forEach(function(prop) {
     if (!self.file.has(['packages', prop.key, 'map']))
       return;
@@ -561,7 +561,7 @@ JspmSystemConfig.prototype.syncFile = function() {
 
   if (this.transpiler)
     this.file.setValue(['transpiler'], this.transpiler != 'none' ? this.transpiler : false);
-  
+
   if (this.browserBaseURL) {
     if (!this.file.has(['browserConfig', 'baseURL']) && this.file.has(['baseURL']))
       this.file.setValue(['baseURL'], this.browserBaseURL == '/' ? '/' : this.browserBaseURL.substr(0, this.browserBaseURL.length - 1));
@@ -595,9 +595,9 @@ JspmSystemConfig.prototype.syncFile = function() {
         nodePath = nodePath.substr(config.pjson.baseURL.length + 1);
       nodePath = nodePath.replace(/\\/g, '/');
     }
-    
 
-    if (!self.browserFile && typeof nodePath == 'string' && typeof browserPath == 'string' && 
+
+    if (!self.browserFile && typeof nodePath == 'string' && typeof browserPath == 'string' &&
         isPlain(browserPath) && browserPath == nodePath) {
       // path collapse when browser = node path and we're not using a separate browser config file
       self.file.remove(['browserConfig', 'paths', name], true);
@@ -693,7 +693,7 @@ function jspmManagedConfigSerialize(obj) {
   var newline = this.style.newline;
   var trailingNewline = this.style.trailingNewline;
 
-  return SystemConfigFile.prototype.serialize.call(this, obj) + newline + (trailingNewline ? '' : newline) + 
+  return SystemConfigFile.prototype.serialize.call(this, obj) + newline + (trailingNewline ? '' : newline) +
     SystemConfigFile.prototype.serialize.call(this, managedCfg);
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -196,7 +196,7 @@ function install(name, target, options, seen) {
   var resolution;
 
   var dependencyDownloads, dependencyDownloadsError;
-  
+
   var linked;
   var alreadyInstalled;
 
@@ -227,7 +227,7 @@ function install(name, target, options, seen) {
         target = targetRange;
         return;
       }
-      
+
       // continue to use exsiting version
       target = config.pjson.peerDependencies[name] || config.pjson.devDependencies[name] || config.pjson.dependencies[name] || target;
       return existing;
@@ -514,7 +514,7 @@ function install(name, target, options, seen) {
         dependencyDownloadsError = e;
       })
       .then(function() {
-        return null
+        return null;
       });
     });
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "bluebird": "^3.0.5",
     "chalk": "^1.1.1",
+    "checksum": "^0.1.1",
     "core-js": "^1.2.6",
     "glob": "^6.0.1",
     "graceful-fs": "^4.1.2",

--- a/test/pjson.js
+++ b/test/pjson.js
@@ -17,7 +17,7 @@ suite('package.json', function() {
         fs.unlinkSync(test.file.fileName);
       }
       catch(e) {}
-      test.file.timestamp = -1;
+      test.file.checksum = -1;
       test.write();
       var expected = fs.readFileSync('./test/fixtures/pjson/expected/' + input).toString();
       var actual = fs.readFileSync('./test/outputs/pjson/' + input).toString();

--- a/testlibs/package.json
+++ b/testlibs/package.json
@@ -99,6 +99,26 @@
         }
       }
     },
+    "npm:debug@2.2.0": {
+      "main": "browser.js",
+      "jspmNodeConversion": false,
+      "format": "cjs",
+      "map": {
+        "./browser.js": {
+          "node": "./node.js"
+        },
+        "fs": "@node/fs",
+        "net": "@node/net",
+        "tty": "@node/tty",
+        "util": "@node/util"
+      }
+    },
+    "npm:lodash@4.13.1": {
+      "map": {
+        "buffer": "@empty",
+        "process": "@empty"
+      }
+    },
     "npm:mocha@1.21.5": {
       "browser": "mocha",
       "main": "mocha",
@@ -114,6 +134,10 @@
           "exports": "mocha"
         }
       }
+    },
+    "npm:ms@0.7.1": {
+      "jspmNodeConversion": false,
+      "format": "cjs"
     },
     "npm:readable-stream@1.0.33": {
       "map": {


### PR DESCRIPTION
I'm working on a project that uses programmatic jspm api. To be able to properly unit test, it's necessary to tear down and setup new environments each time, which means multiple `jspm.install(true)` calls. As it stands the following error is getting in the way:
`Configuration file "jspm.config.js" has been modified by another process.`. 
In this pull request, I provide an alternative that serves my needs and continues to serve the intended case (which I assume to be config file integrity and opt-in management). If there is another way to accomplish this without having to modify the code, please do let me know. 
