### PR TITLE
Fix the jspm inspect registry:name when there are forks

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -710,7 +710,7 @@ function loadExistingRange(name, parent, inject) {
       });
     })
     .then(function(deps) {
-      return deps[name];
+      return parent ? deps[(new PackageName(parent)).exactName][name] : deps[name];
     });
   })
   .then(function(target) {


### PR DESCRIPTION
Currently, this only shows top level dependencies.
This commit allows to show all the forks and what their parent
packages are.

This was previously discussed in PR #1968 as a new feature,
while it was actually a bug.

Example output:

    Installed versions of npm:d3

       d3 4.1.1 (^4.1.1)

       npm:d3-heatmap@1.2.1
         d3 3.5.17 (^3.5.16)