### PR TITLE
fix jspm run not exiting with code 1 after error

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -39,6 +39,7 @@ var link = require('./lib/link');
 
 process.on('uncaughtException', function(err) {
   ui.log('err', err.stack || err);
+  process.exit(1);
 });
 
 /* jshint laxbreak: true */
@@ -191,7 +192,10 @@ process.on('uncaughtException', function(err) {
   switch(args[0]) {
     case 'run':
       options = readOptions(args, ['view', 'production']);
-      core.run(args[1], options.view, options.production);
+      core.run(args[1], options.view, options.production)
+      .catch(function() {
+        process.exit(1);
+      });
       break;
 
     case 'inject':

--- a/lib/core.js
+++ b/lib/core.js
@@ -54,6 +54,7 @@ exports.run = function(moduleName, view, production) {
   })
   .catch(function(e) {
     ui.log('err', e.stack || e);
+    throw e;
   });
 };
 


### PR DESCRIPTION
similar to my other PRs 🔸 
also happened to once again catch in a CI build.

the direct .catch is for errors in system.import (e.g. file not found, or the module throws on loading) and the uncaughtException exit is for any other error.