### PR TITLE
Improve init defaults for TypeScript projects

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -809,7 +809,7 @@ function initPrompts(newProject) {
       }
     })
     .then(function(transpiler) {
-      if (transpiler === 'none')
+      if (transpiler === curTranspiler || transpiler === 'none')
         return;
 
       // set transpiler on BOTH the transpiler and local package loader config
@@ -827,9 +827,6 @@ function initPrompts(newProject) {
           pkgMeta[pkgExt].loader = pkgMeta[pkgExt].loader || 'plugin-' + transpiler.toLowerCase();
       }
       loader.transpiler = 'plugin-' + transpiler.toLowerCase();
-
-      if (transpiler === curTranspiler)
-        return;
 
       // download transpiler
       var installObj = {};

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -789,8 +789,8 @@ function initPrompts(newProject) {
 
     var curTranspiler = loader.transpiler;
 
-    // default transpiler will be typescript only if the main loader file ends with .ts
-    var defTranspiler = /\.ts$/.test(loader.package && loader.package.main) ? 'typescript' : 'babel';
+    // default transpiler will be typescript only if the main loader file ends with .ts or .tsx
+    var defTranspiler = /\.tsx?$/.test(loader.package && loader.package.main) ? 'typescript' : 'babel';
 
     if (curTranspiler && (curTranspiler.substr(0, 7) == 'plugin-' || curTranspiler.substr(0, 7) == 'loader-') && 
         transpilers.indexOf(curTranspiler.substr(7).toLowerCase()) != -1)
@@ -809,18 +809,27 @@ function initPrompts(newProject) {
       }
     })
     .then(function(transpiler) {
-      if (transpiler === curTranspiler || transpiler == 'none')
+      if (transpiler === 'none')
         return;
 
       // set transpiler on BOTH the transpiler and local package loader config
       if (loader.package) {
+        var tsExts = transpiler === 'typescript' && loader.package.main && /\.(tsx?$)/i.exec(loader.package.main);
+        // when typescript is the transpiler set the default package extension to .ts or .tsx
+        if (!loader.package.defaultExtension && tsExts)
+            loader.package.defaultExtension = tsExts[1];
+
         var pkgMeta = loader.package.meta = loader.package.meta || {};
-        var pkgExt = transpiler === 'typescript' ? '*.ts' : '*.js';
+        var pkgExt = transpiler === 'typescript' && tsExts ? '*.' + tsExts[1] : '*.js';
+
         pkgMeta[pkgExt] = pkgMeta[pkgExt] || {};
         if (!pkgMeta[pkgExt].loader || pkgMeta[pkgExt].loader == loader.transpiler)
           pkgMeta[pkgExt].loader = pkgMeta[pkgExt].loader || 'plugin-' + transpiler.toLowerCase();
       }
       loader.transpiler = 'plugin-' + transpiler.toLowerCase();
+
+      if (transpiler === curTranspiler)
+        return;
 
       // download transpiler
       var installObj = {};


### PR DESCRIPTION
This resolves #2110 by making the following changes to the `init` command
  1. Include `"defaultExtension": "ts"` in local package config when the `transpiler` is inferred to be TypeScript. For example this will now happen when the local package main is specified as `app.ts`.

  2. Inferring TypeScript as the transpiler when the local package package main has a `.tsx` extension, as should be the case for TypeScript React projects. In this case add `"defaultExtension": "tsx"` to local package config.