### PR TITLE
feat(hooks): add postinstall and preinstall hook support

### DIFF
--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -37,6 +37,7 @@ var config = require('./index');
  * - peerDependencies
  * - devDependencies
  * - overrides
+ * - hooks
  *
  * Public Methods
  * - write
@@ -85,9 +86,11 @@ function PackageConfig(fileName) {
       'dependencies',
       'devDependencies',
       'peerDependencies',
-      'overrides'
+      'overrides',
+      'hooks'
     ]],
-    'overrides'
+    'overrides',
+    'hooks'
   ]);
 
   this.dir = path.dirname(path.resolve(fileName));
@@ -106,6 +109,7 @@ function PackageConfig(fileName) {
     this.jspmPrefix = true;
 
   this.name = prefixedGetValue.call(this, ['name'], 'string') || !this.jspmAware && 'app';
+  this.hooks = prefixedGetObject.call(this, ['hooks'], true);
 
   var baseURLValue = prefixedGetValue.call(this, ['directories', 'baseURL'], 'string') || '';
   if (baseURLValue[0] == '/' || baseURLValue.indexOf('//') != -1 || baseURLValue.indexOf('\\\\') != -1 || baseURLValue.indexOf(':') != -1) {

--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -87,10 +87,16 @@ function PackageConfig(fileName) {
       'devDependencies',
       'peerDependencies',
       'overrides',
-      'hooks'
+      ['hooks', [
+        'preinstall',
+        'postinstall'
+      ]]
     ]],
     'overrides',
-    'hooks'
+    ['hooks', [
+        'preinstall',
+        'postinstall'
+    ]]
   ]);
 
   this.dir = path.dirname(path.resolve(fileName));

--- a/lib/install.js
+++ b/lib/install.js
@@ -86,6 +86,24 @@ exports.install = function(targets, options) {
   options = options || {};
 
   return config.load()
+  .then(function () {
+    var hooks = config.pjson.hooks;
+    if (hooks) {
+      return new Loader().import(hooks.preinstall)
+        .then(function (m) {
+          if (m.default && typeof m.default === 'function') {
+            ui.log('info', 'Running preinstall hook...');
+            return Promise.resolve(m.default());
+          }
+        })
+        .catch(function (error) {
+          if (error) {
+            ui.log('err', 'Error during preinstall hook');
+            ui.log('err', error);
+          }
+        });
+    }
+  })
   .then(function() {
     installed = installed || config.loader;
     secondaryRanges = secondaryRanges || config.deps;
@@ -147,13 +165,22 @@ exports.install = function(targets, options) {
       return saveInstall();
     })
     .then(function () {
-      return new Loader().import(config.pjson.hooks.postinstall)
-        .catch(function (error) {
-          if (error) {
-            ui.log('err', 'Error during postinstall hook');
-            ui.log('err', error);
-          }
-        });
+      var hooks = config.pjson.hooks;
+      if (hooks) {
+        return new Loader().import(hooks.postinstall)
+          .then(function (m) {
+            if (m.default && typeof m.default === 'function') {
+              ui.log('info', 'Running postinstall hook...');
+              return Promise.resolve(m.default());
+            }
+          })
+          .catch(function (error) {
+            if (error) {
+              ui.log('err', 'Error during postinstall hook');
+              ui.log('err', error);
+            }
+          });
+      }
     })
     .then(function() {
       // after every install, show fork and resolution summary

--- a/lib/install.js
+++ b/lib/install.js
@@ -26,7 +26,6 @@ var PackageName = require('./package-name');
 var ui = require('./ui');
 var path = require('path');
 var globalConfig = require('./config/global-config');
-var System = require('systemjs');
 
 var rimraf = require('rimraf');
 
@@ -36,7 +35,7 @@ var hasProperties = require('./common').hasProperties;
 var processDeps = require('./common').processDeps;
 var extend = require('./common').extend;
 
-var api = require('../api');
+var Loader = require('../api').Loader;
 
 var fs = require('graceful-fs');
 
@@ -148,13 +147,13 @@ exports.install = function(targets, options) {
       return saveInstall();
     })
     .then(function () {
-      var hooks = config.pjson.hooks;
-      if (hooks) {
-        if ('postinstall' in hooks && typeof hooks.postinstall === 'string') {
-          System.config(config.getLoaderConfig());
-          return api.import(hooks.postinstall);
-        }
-      }
+      return new Loader().import(config.pjson.hooks.postinstall)
+        .catch(function (error) {
+          if (error) {
+            ui.log('err', 'Error during postinstall hook');
+            ui.log('err', error);
+          }
+        });
     })
     .then(function() {
       // after every install, show fork and resolution summary

--- a/lib/install.js
+++ b/lib/install.js
@@ -51,6 +51,25 @@ var installing = {
   depMap: {}
 };
 
+function runHook(name) {
+  var hooks = config.pjson.hooks;
+  if (hooks && hooks[name]) {
+    return new Loader().import(hooks[name])
+      .then(function (m) {
+        if (m.default && typeof m.default === 'function') {
+          ui.log('info', 'Running ' + name + ' hook...');
+          return Promise.resolve(m.default());
+        }
+      })
+      .catch(function (error) {
+        ui.log('err', 'Error during ' + name + ' hook');
+        if (error) {
+          ui.log('err', error);
+        }
+      });
+  }
+}
+
 /*
  * Main install API wrapper
  *
@@ -87,22 +106,7 @@ exports.install = function(targets, options) {
 
   return config.load()
   .then(function () {
-    var hooks = config.pjson.hooks;
-    if (hooks) {
-      return new Loader().import(hooks.preinstall)
-        .then(function (m) {
-          if (m.default && typeof m.default === 'function') {
-            ui.log('info', 'Running preinstall hook...');
-            return Promise.resolve(m.default());
-          }
-        })
-        .catch(function (error) {
-          if (error) {
-            ui.log('err', 'Error during preinstall hook');
-            ui.log('err', error);
-          }
-        });
-    }
+    return runHook('preinstall');
   })
   .then(function() {
     installed = installed || config.loader;
@@ -165,22 +169,7 @@ exports.install = function(targets, options) {
       return saveInstall();
     })
     .then(function () {
-      var hooks = config.pjson.hooks;
-      if (hooks) {
-        return new Loader().import(hooks.postinstall)
-          .then(function (m) {
-            if (m.default && typeof m.default === 'function') {
-              ui.log('info', 'Running postinstall hook...');
-              return Promise.resolve(m.default());
-            }
-          })
-          .catch(function (error) {
-            if (error) {
-              ui.log('err', 'Error during postinstall hook');
-              ui.log('err', error);
-            }
-          });
-      }
+      return runHook('postinstall');
     })
     .then(function() {
       // after every install, show fork and resolution summary

--- a/lib/install.js
+++ b/lib/install.js
@@ -26,6 +26,7 @@ var PackageName = require('./package-name');
 var ui = require('./ui');
 var path = require('path');
 var globalConfig = require('./config/global-config');
+var System = require('systemjs');
 
 var rimraf = require('rimraf');
 
@@ -141,6 +142,15 @@ exports.install = function(targets, options) {
 
       return install(name, targets[name], opts);
     }))
+    .then(function() {
+      var hooks = config.pjson.hooks;
+      if(hooks) {
+        if('postinstall' in hooks && typeof hooks.postinstall === 'string') {
+          System.config(config.getLoaderConfig());
+          return System.import(hooks.postinstall);
+        }
+      }
+    })
     .then(function() {
       return saveInstall();
     })

--- a/lib/install.js
+++ b/lib/install.js
@@ -36,6 +36,8 @@ var hasProperties = require('./common').hasProperties;
 var processDeps = require('./common').processDeps;
 var extend = require('./common').extend;
 
+var api = require('../api');
+
 var fs = require('graceful-fs');
 
 var primaryRanges = {};
@@ -143,16 +145,16 @@ exports.install = function(targets, options) {
       return install(name, targets[name], opts);
     }))
     .then(function() {
+      return saveInstall();
+    })
+    .then(function () {
       var hooks = config.pjson.hooks;
-      if(hooks) {
-        if('postinstall' in hooks && typeof hooks.postinstall === 'string') {
+      if (hooks) {
+        if ('postinstall' in hooks && typeof hooks.postinstall === 'string') {
           System.config(config.getLoaderConfig());
-          return System.import(hooks.postinstall);
+          return api.import(hooks.postinstall);
         }
       }
-    })
-    .then(function() {
-      return saveInstall();
     })
     .then(function() {
       // after every install, show fork and resolution summary


### PR DESCRIPTION
Part of https://github.com/jspm/jspm-cli/issues/1899

I went with the simplest solution of just executing a hook script with no arguments.
@guybedford Could you have a look at this and tell me, if it is alright. If so I will add a `preinstall` hook [here](https://github.com/jspm/jspm-cli/blob/master/lib/install.js#L88).