### PR TITLE
Implement #1977: --exact flag for pinning latest version of dependency

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -70,6 +70,7 @@ process.on('uncaughtException', function(err) {
       + '  install react --lock           Stable install, locking existing dependencies\n'
       + '  install react=npm:react --edge Install a package alias to latest unstable\n'
       + '  install react --quick          Quick install, skipping tree hash verifications\n'
+      + '  install react --exact          Install and pin the latest version of a package\n'
       + '\n'
       + '  install dep -o override.json   Install with the given custom override\n'
       + '  install dep -o "{json}"        useful for testing package overrides\n'
@@ -214,7 +215,7 @@ process.on('uncaughtException', function(err) {
     case 'i':
     case 'isntall':
     case 'install':
-      options = readOptions(args, ['force', 'yes', 'lock', 'latest',
+      options = readOptions(args, ['force', 'yes', 'lock', 'latest', 'exact',
                                    'unlink', 'quick', 'dev', 'save-dev', 'edge', 'production', 'peer'], ['override']);
 
       if (options['save-dev']) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -316,9 +316,12 @@ function install(name, target, options, seen) {
         throw 'No version match found for `' + target.exactName + '`';
     }
 
+    if (options.exact) {
+      target.setVersion(resolution.version);
+    }
     // if no version range was specified on install, install to semver-compatible with the latest
-    if (!options.parent && !target.version) {
-      if (!options.exact && resolution.version.match(semver.semverRegEx))
+    else if (!options.parent && !target.version) {
+      if (resolution.version.match(semver.semverRegEx))
         target.setVersion('^' + resolution.version);
       else
         target.setVersion(resolution.version);

--- a/lib/install.js
+++ b/lib/install.js
@@ -318,7 +318,7 @@ function install(name, target, options, seen) {
 
     // if no version range was specified on install, install to semver-compatible with the latest
     if (!options.parent && !target.version) {
-      if (resolution.version.match(semver.semverRegEx))
+      if (!options.exact && resolution.version.match(semver.semverRegEx))
         target.setVersion('^' + resolution.version);
       else
         target.setVersion(resolution.version);


### PR DESCRIPTION
See #1977. The `--exact` flag is intended to be similar to npm's [save-exact](https://docs.npmjs.com/cli/install) flag, where you don't have to specify the version but it still pins the dependency to the latest version.

I saw that you put the discussion label on #1977 and am not sure if that means there was more to talk about before creating a pull request -- if so let me know.
