### PR TITLE
update typescript option to install latest stable

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -45,7 +45,7 @@ var tPackages = {
   'core-js':         'npm:core-js@^1.1.4',
   'traceur':         'github:jmcriffey/bower-traceur@0.0.93',
   'traceur-runtime': 'github:jmcriffey/bower-traceur-runtime@0.0.93',
-  'typescript':      'npm:typescript@^1.6.2'
+  'typescript':      'npm:typescript@^2.0.7'
 };
 
 exports.run = function(moduleName) {


### PR DESCRIPTION
The code emit changes between these major versions all expand TypeScript's support for transpiling ES2015 syntax. A few involve better SystemJS support and I think this upgrade will be beneficial overall. That said, I primarily use TypeScript via plugin-typescript.

This would resolve #2145