### PR TITLE
fix setting of jspm prefix in package.json

### DIFF
--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -190,12 +190,7 @@ PackageConfig.prototype.populateDefaultPaths = function() {
 };
 
 PackageConfig.prototype.setPrefix = function(jspmPrefix) {
-  // removes the "jspm" property in the package.json
-  // flattening it down the to base-level
-  if (this.jspmPrefix && this.file.has(['jspm']) && !jspmPrefix) {
-    var jspmProperties = this.file.getProperties(['jspm']);
-    var baseProperties = this.file.getProperties([]);
-
+  if (this.jspmPrefix && !jspmPrefix) {
     var depsPrefixed = this.depsPrefixed;
     if (depsPrefixed) {
       this.file.remove(['dependencies']);
@@ -203,17 +198,24 @@ PackageConfig.prototype.setPrefix = function(jspmPrefix) {
       this.file.remove(['devDependencies']);
     }
 
-    var self = this;
+    // removes the "jspm" property in the package.json
+    // flattening it down the to base-level
+    if (this.file.has(['jspm'])) {
+      var jspmProperties = this.file.getProperties(['jspm']);
+      var baseProperties = this.file.getProperties([]);
+      var self = this;
 
-    jspmProperties.forEach(function(prop) {
-      self.file.remove([prop.key]);
-      baseProperties.push(prop);
-    });
-
-    this.file.remove(['jspm']);
+      jspmProperties.forEach(function(prop) {
+        self.file.remove([prop.key]);
+        baseProperties.push(prop);
+      });
+      
+      this.file.remove(['jspm']);
+    }
 
     this.file.changed = true;
     this.jspmPrefix = false;
+    this.depsPrefixed = false;
   }
   else if (!this.jspmPrefix && jspmPrefix) {
     this.jspmPrefix = true;


### PR DESCRIPTION
Using custom init mode and set `Prefix package.json properties under jspm?: No` the generated `package.json` has a `jspm` entry:
```
{
  "jspm": {
    "name": "app",
    "main": "app.js",
    "devDependencies": {
      "plugin-babel": "npm:systemjs-plugin-babel@^0.0.17"
    }
  }
}
```
Also "converting" an package with existing `jspmPrefix` is buggy:
```
{
  "name": "app",
  "main": "app.js",
  "devDependencies": {
    "plugin-babel": "npm:systemjs-plugin-babel@^0.0.17"
  },
  "jspm": {
    "devDependencies": {
      "plugin-babel": "npm:systemjs-plugin-babel@^0.0.17"
    }
  }
}
```

With these changes the `package.json` has in both case the following structure:
```
{
  "name": "app",
  "main": "app.js",
  "devDependencies": {
    "plugin-babel": "npm:systemjs-plugin-babel@^0.0.17"
  },
  "jspm": true
}
```