### PR TITLE
fix setting of jspm and deps prefix

### DIFF
--- a/lib/config/package.js
+++ b/lib/config/package.js
@@ -212,17 +212,13 @@ PackageConfig.prototype.setPrefix = function(jspmPrefix) {
 
     this.file.remove(['jspm']);
 
-    this.depsPrefixed = false;
     this.file.changed = true;
   }
   else if (!this.jspmPrefix && jspmPrefix) {
-    this.jspmPrefix = true;
-    this.depsBase = ['jspm'];
-
     if (this.file.getValue(['jspm']))
       this.file.remove(['jspm']);
   }
-  this.jspmPrefix = jspmPrefix;
+  this.jspmPrefix = this.depsPrefixed = jspmPrefix;
 };
 
 PackageConfig.prototype.write = function() {


### PR DESCRIPTION
`depsPrefixed` is not set correctly, if no `package.json` exists.

Set `depsBase` has no effect because the value is going to be overridden based on the `depsPrefixed` value when writing the file.