### PR TITLE
[0.17] Allow to use transpiler in bundle if there is no package.json in a temp folder

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -395,7 +395,7 @@ exports.loadSync = function(allowNoConfig) {
   }
   config.loader = new JspmSystemConfig(config.pjson.configFile);
 
-  if (!config.pjson.jspmAware && allowNoConfig)
+  if (!config.loader.transpiler && allowNoConfig)
     config.loader.transpiler = 'none';
 
   var depsJSON;


### PR DESCRIPTION
This quick fix allows transpilation to be available with bundling when package.json is not found in the same directory.

To add a little bit of context, I am copying all source files (including jspm config files) in a temporary folder where I am doing some post-process with them (adding CDN path, etc...).

I was able to call `jspm build ...` (cwd the temp folder) to bundle with `Rollup` correctly, but transpilation was only possible if package.json was there. (my bundle was containing es2015 features and I want to support older browser). This is the same issue for `jspm bundle ...`.


**I temporary fixed it by copying `package.json` into that temp folder, but as we already have the transpiler information within the jspm config file.**

@guybedford : let me know if you think there is another way than that fix.


Thank you