### PR TITLE
Fixing package overrides where shim name ends with '.js'. See #2197

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -306,7 +306,8 @@ function upgradePackageConfig(packageConfig) {
         continue;
 
       var curShim = packageConfig.shim[s];
-      var curMeta = packageConfig.meta[s + '.js'] = {};
+      var metaName = s.endsWith('.js') ? s : s + '.js';
+      var curMeta = packageConfig.meta[metaName] = {};
 
       if (curShim instanceof Array) {
         curMeta.deps = curShim;


### PR DESCRIPTION
See #2197. The package override in the jspm registry for angular-ui-router@0.3.1 does not work anymore because `upgradePackageConfig` appends an extra `.js` to `shim` names that already have a `.js` in them. See [example of a broken package override](https://github.com/jspm/registry/blob/master/package-overrides/github/angular-ui/angular-ui-router-bower%400.3.1.json), [the jspm commit that caused the bug](https://github.com/jspm/jspm-cli/commit/3944cb3bf346a0f47b107937e2de5683f96c944b#diff-8eaf344b0d37588331d22edb952ddd05R320), and [the issue reported for angular-ui-router](https://github.com/jspm/jspm-cli/issues/2197)