### PR TITLE
build: Explain incompatibility between --format esm and --minify

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -479,6 +479,9 @@ process.on('uncaughtException', function(err) {
       if (bArgs.length === 0)
         return ui.log('warn', 'You must provide at least one module as the starting point for bundling');
 
+      if (options.format && options.format.match(/es.?/) && options.minify) // remove this on resolution of https://github.com/systemjs/builder/issues/726
+        return ui.log('warn', 'The %--minify% option is currently not compatible with %--format ' + options.format + '%, consider specifying a different format or skipping minification');
+
       if (bArgs.length < 2) {
         (staticBuild ? bundle.build : bundle.bundle)(bArgs[0], undefined, options)
         .catch(function() {


### PR DESCRIPTION
Based on https://github.com/jspm/jspm-cli/issues/2174 and on my own experience running into the same incompatibility, I think it would be beneficial to provide a warning when combining the `--format esm` and `--minify` options to the build command until the SystemJS Builder is enhanced to use Babili for minification (https://github.com/systemjs/builder/issues/726).