### PR TITLE
use mkdirp to create global config path

### DIFF
--- a/lib/config/global-config.js
+++ b/lib/config/global-config.js
@@ -16,6 +16,7 @@
 
 var ui = require('../ui');
 var fs = require('graceful-fs');
+var mkdirp = require('mkdirp');
 var path = require('path');
 var lockFile = require('proper-lockfile');
 var dprepend = require('../common').dprepend;
@@ -40,7 +41,7 @@ function GlobalConfigFile(homePath) {
     try {
       ui.log('info', 'Copying configuration...');
       var oldConfig = fs.readFileSync(path.resolve(from, 'config'));
-      fs.mkdirSync(to);
+      mkdirp.sync(to);
       fs.writeFileSync(path.resolve(to, 'config'), oldConfig);
       ui.log('ok', 'Migration successful. Note that linked packages will need to be relinked.');
     }
@@ -101,7 +102,7 @@ GlobalConfigFile.prototype.constructor = GlobalConfigFile;
 
 GlobalConfigFile.prototype.save = function() {
   try {
-    fs.mkdirSync(path.dirname(this.globalConfigFile));
+    mkdirp.sync(path.dirname(this.globalConfigFile));
   }
   catch (e) {
     if (e.code !== 'EEXIST')


### PR DESCRIPTION
If `JSPM_GLOBAL_PATH` points to a directory that doesn't exist, jspm should create that directory.