### PR TITLE
backtickets are not shown when using jspm

### DIFF
--- a/lib/config/global-config.js
+++ b/lib/config/global-config.js
@@ -37,7 +37,7 @@ function GlobalConfigFile(homePath) {
     var OLD_HOME = process.env.USERPROFILE;
     var from = path.join(OLD_HOME, '.jspm');
     var to = path.join(HOME, '.jspm');
-    ui.log('info', 'Migrating global jspm folder from `' + from + '` to `' + to + '`...');
+    ui.log('info', 'Migrating global jspm folder from "' + from + '" to "' + to + '"...');
     try {
       ui.log('info', 'Copying configuration...');
       var oldConfig = fs.readFileSync(path.resolve(from, 'config'));


### PR DESCRIPTION
backtickets are not shown when using jspm on the command line with nodejs see #https://github.com/jspm/jspm-cli/issues/2333