### PR TITLE
backtickets are not shown when using jspm

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -127,7 +127,7 @@ exports.depCache = function(expression) {
 
   expression = expression || config.loader.main;
 
-  ui.log('info', 'Injecting the traced dependency tree for `' + expression + '`...');
+  ui.log('info', 'Injecting the traced dependency tree for "' + expression + '"...');
 
   return systemBuilder.trace(expression, { browser: true })
   .then(function(tree) {


### PR DESCRIPTION
backtickets are not shown when using jspm on the command line with nodejs see #https://github.com/jspm/jspm-cli/issues/2333