### PR TITLE
fix: showInstallGraph fails if a config is missing from package.json

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -1017,12 +1017,19 @@ function showInstallGraph(pkg) {
     ui.log('info', '\nInstalled versions of %' + pkg.name + '%');
     visitForkRanges(installed, pkg, null, null, function(name, parent, resolved, range) {
       found = true;
-      if (range.version === '')
-        range.version = '*';
-      var rangeVersion = range.name === resolved.name ? range.version : range.exactName;
-      if (range.version === '*')
-        range.version = '';
-
+      var rangeVersion;
+      if (range) {
+        if (range.version === '') {
+          range.version = '*';
+        }
+        rangeVersion = range.name === resolved.name ? range.version : range.exactName;
+        if (range.version === '*') {
+          range.version = '';
+        }
+      }
+      else {
+        rangeVersion = resolved.version; 
+      }
       if (!parent)
         ui.log('info', '\n       %' + name + '% `' + resolved.version + '` (' + rangeVersion + ')');
       else {

--- a/lib/install.js
+++ b/lib/install.js
@@ -1027,17 +1027,15 @@ function showInstallGraph(pkg) {
           range.version = '';
         }
       }
-      else {
-        rangeVersion = resolved.version; 
+      if (!parent) {
+        ui.log('info', '\n       %' + name + '% `' + resolved.version + '`' + (range ? ' (' + rangeVersion + ')' : ''));
       }
-      if (!parent)
-        ui.log('info', '\n       %' + name + '% `' + resolved.version + '` (' + rangeVersion + ')');
       else {
         if (lastParent !== parent) {
           ui.log('info', '\n  ' + parent);
           lastParent = parent;
         }
-        ui.log('info', '    ' + name + ' `' + resolved.version + '` (' + rangeVersion + ')');
+        ui.log('info', '    ' + name + ' `' + resolved.version + '`' + (range ? ' (' + rangeVersion + ')' : ''));
       }
     });
     if (!found)


### PR DESCRIPTION
When running
```shell
$jspm inspect registry:depname
```
where depname is mapped in a configuration file but is not a dependency in `package.json`, an error is thrown by the `showInstallGraph` method. This happens because the `range` argument is `undefined` under these circumstances.

This happens after the warning is correctly printed, but is distracting, making the warning itself easy to miss.

This fix falls back to using the value of `resolved.version` which is likely not ideal behavior either.
Perhaps we should print `'unspecified'` or something of the sort.