### PR TITLE
Fix packages folder path in mapping

### DIFF
--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -181,7 +181,7 @@ class Mapper {
       return await cached;
     
     return await (this.cachedPackagePaths[pkgName] = (async () => {
-      const pjson = await readJSON(`${this.project.projectPath}/jspm_packages/${pkgName.replace(':', '/')}/package.json`);
+      const pjson = await readJSON(`${this.project.config.pjson.packages}/${pkgName.replace(':', '/')}/package.json`);
 
       if (!pjson)
         throw new JspmUserError(`Package ${highlight(pkgName)} is not installed correctly. Run jspm install.`);

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -287,7 +287,7 @@ class MapResolver {
   mapResolve: (id: string, parentUrl: string) => string;
 
   constructor (project: Project, map: ImportMap) {
-    let baseDir = project.projectPath;
+    let baseDir = project.config.pjson.baseURL;
     this.project = project;
     this.imports = map.imports;
 


### PR DESCRIPTION
My `jspm_packages` folder could be in a subfolder with in this config :
```json 
"directories": {
  "baseURL": "public"
}
```