### PR TITLE
Fix mapping with no scoped packages

### DIFF
--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -296,14 +296,16 @@ class MapResolver {
       baseDir += '/';
     const baseURL = new URL('file:' + baseDir).href;
 
-    for (const scopeName of Object.keys(map.scopes)) {
-      let resolvedScopeName = resolveIfNotPlainOrUrl(scopeName, baseURL) || scopeName.indexOf(':') !== -1 && scopeName || resolveIfNotPlainOrUrl('./' + scopeName, baseURL);
-      if (resolvedScopeName[resolvedScopeName.length - 1] !== '/')
-        resolvedScopeName += '/';
-      this.scopes[resolvedScopeName] = {
-        originalName: scopeName,
-        imports: map.scopes[scopeName] || {}
-      };
+    if (map.scopes !== undefined) {
+      for (const scopeName of Object.keys(map.scopes)) {
+        let resolvedScopeName = resolveIfNotPlainOrUrl(scopeName, baseURL) || scopeName.indexOf(':') !== -1 && scopeName || resolveIfNotPlainOrUrl('./' + scopeName, baseURL);
+        if (resolvedScopeName[resolvedScopeName.length - 1] !== '/')
+          resolvedScopeName += '/';
+        this.scopes[resolvedScopeName] = {
+          originalName: scopeName,
+          imports: map.scopes[scopeName] || {}
+        };
+      }
     }
     this.trace = Object.create(null);
     this.usedMap = { imports: {}, scopes: {} };


### PR DESCRIPTION
```shell
$ jspm map ./test.js
```
will fail with :

```
err  TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at new MapResolver ([...]/node_modules/jspm/lib/map/index.js:221:40)
    at Object.filterMap ([...]/node_modules/jspm/lib/map/index.js:323:24)
    at cliHandler ([...]/node_modules/jspm/lib/cli.js:309:41)
```

`package.json` :
```json
{
  "name": "app",
  "dependencies": {
    "lodash": "^4.17.11"
  },
  "devDependencies": {
    "@jspm/core": "^1.0.4"
  },
  "type": "module"
}
```

`test.js` :
```javascript
import clone from "lodash/clone.js";

console.log(clone({ a: 'b' }));
```