### PR TITLE
Fix unix bin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 env:
   global:
     - COVERAGE=false
+    - GIT_TERMINAL_PROMPT=0
 matrix:
   include:
     - node_js: '10'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ env:
     - COVERAGE=false
 matrix:
   include:
-    - node_js: '6'
-    - node_js: '7'
+    - node_js: '10'
+    - node_js: '12'
     #
     - node_js: node
       env: COVERAGE=true

--- a/src/install/bin.ts
+++ b/src/install/bin.ts
@@ -72,6 +72,9 @@ if [ "$?" != "0" ] || [ -z "$JSPM_PATH" ]; then
   exit 1
 fi
 JSPM_DIR=$(dirname $(dirname $(readlink $JSPM_PATH || $JSPM_PATH)))
+case $JSPM_DIR in /*) ;; *)
+  JSPM_DIR="$(dirname $JSPM_PATH)/$JSPM_DIR"
+esac
 JSPM_LOADER=$JSPM_DIR/node_modules/@jspm/resolve/loader.mjs
 if [ ! -f $JSPM_LOADER ]; then
   echo "jspm loader not found, make sure it is installed."

--- a/src/install/bin.ts
+++ b/src/install/bin.ts
@@ -65,20 +65,15 @@ exit $ret
 `;
 
 const unixBin = (binModulePath: string) => `#!/bin/sh
-BASE_DIR=$(dirname $(dirname $(realpath $0)))
+BASE_DIR=$(dirname $(dirname $0))
 JSPM_PATH=$(which jspm 2>/dev/null)
 if [ "$?" != "0" ] || [ -z "$JSPM_PATH" ]; then
   echo "jspm not found, make sure it is installed."
   exit 1
 fi
-if [ $(realpath "$JSPM_PATH") = $JSPM_PATH ] && [ -d $(dirname "$JSPM_PATH")/node_modules/jspm ]; then
-  JSPM_DIR=$(dirname "$JSPM_PATH")/node_modules/jspm
-else
-  JSPM_DIR=$(dirname $(dirname $(realpath "$JSPM_PATH")))
-fi
-if [ -d $JSPM_DIR/node_modules ]; then
-  JSPM_LOADER=$JSPM_DIR/node_modules/@jspm/resolve/loader.mjs
-else
+JSPM_DIR=$(dirname $(dirname $(readlink $JSPM_PATH || $JSPM_PATH)))
+JSPM_LOADER=$JSPM_DIR/node_modules/@jspm/resolve/loader.mjs
+if [ ! -f $JSPM_LOADER ]; then
   echo "jspm loader not found, make sure it is installed."
   exit 1
 fi


### PR DESCRIPTION
This fixes the MacOS support for the unix bin file which was using `realpath` which isn't supported on Mac by default. This updates the implementation to use `readlink` instead.

Resolves https://github.com/jspm/jspm-cli/issues/2460 and should actually get the website beta guide running on Mac! 