### PR TITLE
Add no-relative-deps option to trace cmd

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -277,7 +277,7 @@ ${bold('Command Flags')}
       case 't':
       case 'trace': {
         let options;
-        ({ args, options } = readOptions(args, ['react-native', 'production', 'electron', 'node', 'deps'], ['out', 'in']));
+        ({ args, options } = readOptions(args, ['react-native', 'production', 'electron', 'node', 'deps', 'no-relative-deps'], ['out', 'in']));
 
         project = new api.Project(projectPath, { offline, preferOffline, userInput, cli: true });
         const map = await api.map(project, options);
@@ -291,7 +291,7 @@ ${bold('Command Flags')}
           const deps = new Set();
           for (const map of Object.values(traced)) {
             for (const dep of Object.keys(map)) {
-              if (map[dep] in traced === false)
+              if (map[dep] in traced === false && (!options.noRelativeDeps || options.noRelativeDeps && dep.startsWith(".") === false))
                 deps.add(dep);
             }
           }


### PR DESCRIPTION
Some of my module import module with relative path e.g. `import aaa from "./dir/aaa.js"`.
When I run the command `jspm trace --deps ./app.js` it outputs : 
```
@scope/package
@otherscope/package2
./dir/aaa.js
```
wich is correct. 

But if I want to use the commands you noted in your guide at section `Optimized Dependency Builds` :
```
$ jspm build $(jspm trace --deps ./app.js) -h -o deps-buildmap.json
$ jspm build ./test.js --external deps-buildmap.json
```
it will fail with : 
```
$ jspm build $(jspm trace --deps ./app.js) -h -o deps-buildmap.json
err  Error: Could not load [projectBasePath]/dir/aaa.js: ENOENT: no such file or directory, open '[projectBasePath]/dir/aaa.js'
```

So my proposal is to add an option to exclude relative dependencies as they will be bundle with the second build.