### PR TITLE
Make sure rollup output matching input

### DIFF
--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -179,7 +179,7 @@ export async function build (input: string[] | Record<string,string>, opts: Buil
   
   // Make sure the rollup output array is in the same order as input array
   const inputObjKeys = Object.keys(inputObj);
-  const filteredOutput = output.filter(out => inputObjKeys.indexOf(out.name) !== -1);
+  const filteredOutput = output.filter(out => out.isEntry);
   filteredOutput.sort((a, b) => inputObjKeys.indexOf(a.name) - inputObjKeys.indexOf(b.name));
   
   for (const [index, key] of inputObjKeys.entries()) {

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -179,10 +179,11 @@ export async function build (input: string[] | Record<string,string>, opts: Buil
   
   // Make sure the rollup output array is in the same order as input array
   const inputObjKeys = Object.keys(inputObj);
-  output.sort((a, b) => inputObjKeys.indexOf(a.name) - inputObjKeys.indexOf(b.name));
+  const filteredOutput = output.filter(out => inputObjKeys.indexOf(out.name) !== -1);
+  filteredOutput.sort((a, b) => inputObjKeys.indexOf(a.name) - inputObjKeys.indexOf(b.name));
   
   for (const [index, key] of inputObjKeys.entries()) {
-    const resolvedFile = path.resolve(opts.dir, output[index].fileName);
+    const resolvedFile = path.resolve(opts.dir, filteredOutput[index].fileName);
     let relMap = path.relative(mapBase, resolvedFile).replace(/\\/g, '/');
     if (!relMap.startsWith('../'))
       relMap = './' + relMap;


### PR DESCRIPTION
An other issue with Rollup output (as #2468).
If my external deps share common code, Rollup will create a chunk with this shared code. That's OK.
But Rollup will add this chunk at the output so import map will be wrong again :
```
{
  "imports": {
    "@etdsolutions/request": "./chunk-e62c8060.js",
    "single-spa": "./request-627619e8.js",
    "@etdsolutions/stacks": "./single-spa-2080b5a8.js",
    "@etdsolutions/uid": "./stacks-ff183556.js",
    "@fortawesome/free-solid-svg-icons/faChevronUp.js": "./uid-203f014d.js",
    "@fortawesome/free-solid-svg-icons/faChevronDown.js": "./faChevronUp-0ffe90b6.js",
    "bootstrap.native": "./faChevronDown-577c640c.js",
    "@fortawesome/fontawesome-svg-core": "./bootstrap-c17f3a72.js",
    "@etdsolutions/routie": "./fontawesome-svg-core-00332bf4.js",
    "one": "./routie-ad357c93.js",
    "@erp/ui-components/helpers/notify.js": "./one-54bc149a.js",
    "lodash-es/assign.js": "./notify-556a357a.js",
    "lodash-es/clone.js": "./assign-d637c92e.js"
  }
}
```
Here lodash functions share multiple files.
I fixed that with filtering `output` array.