### PR TITLE
build: fix array instance check

### DIFF
--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -62,7 +62,7 @@ export async function build (input: string[] | Record<string,string>, opts: Buil
     opts.dir = opts.dir.slice(0, -1);
 
   const isRecord = (x: typeof input): x is Record<string, string> => {
-    return x instanceof Array.isArray === false
+    return Array.isArray(x) === false;
   }
 
   let inputObj;


### PR DESCRIPTION
This fixes the Array check, which was something between an `instanceof` and `Array.isArray` check.

Fixes https://github.com/jspm/jspm-cli/pull/2480#issuecomment-505789565.