### PR TITLE
Handle scope normalization as base-relative

### DIFF
--- a/src/map/common.ts
+++ b/src/map/common.ts
@@ -128,7 +128,7 @@ function resolvePackages(pkgs, baseUrl) {
     // TODO package fallback support
     if (typeof value !== 'string')
       continue;
-    outPkgs[resolveIfNotPlainOrUrl(p, baseUrl) || p] = value;
+    outPkgs[resolveIfNotPlainOrUrl(p, baseUrl) || p] = resolveUrl(value, baseUrl);
   }
   return outPkgs;
 }
@@ -142,11 +142,11 @@ export function parseImportMap (json, baseUrl) {
       let resolvedScopeName = resolveUrl(scopeName, baseUrl);
       if (resolvedScopeName[resolvedScopeName.length - 1] !== '/')
         resolvedScopeName += '/';
-      scopes[resolvedScopeName] = resolvePackages(scope, resolvedScopeName) || {};
+      scopes[resolvedScopeName] = resolvePackages(scope, baseUrl) || {};
     }
   }
 
-  return { imports: imports, scopes: scopes, baseUrl: baseUrl };
+  return { imports: imports, scopes: scopes };
 }
 
 function getMatch (path, matchObj) {
@@ -160,15 +160,16 @@ function getMatch (path, matchObj) {
   } while ((sepIndex = path.lastIndexOf('/', sepIndex - 1)) !== -1)
 }
 
-function applyPackages (id, packages, baseUrl) {
+function applyPackages (id, packages) {
   const pkgName = getMatch(id, packages);
   if (pkgName) {
     const pkg = packages[pkgName];
     if (pkg === null)
-
+      return;
     if (id.length > pkgName.length && pkg[pkg.length - 1] !== '/')
       console.warn("Invalid package target " + pkg + " for '" + pkgName + "' should have a trailing '/'.");
-    return resolveUrl(pkg + id.slice(pkgName.length), baseUrl);
+    const subpath = id.slice(pkgName.length);
+    return subpath ? resolveUrl(subpath, pkg) : pkg;
   }
 }
 
@@ -179,11 +180,11 @@ export function resolveImportMap (id, parentUrl, importMap) {
   const scopeName = getMatch(parentUrl, importMap.scopes);
   if (scopeName) {
     const scopePackages = importMap.scopes[scopeName];
-    const packageResolution = applyPackages(id, scopePackages, scopeName);
+    const packageResolution = applyPackages(id, scopePackages);
     if (packageResolution)
       return packageResolution;
   }
-  return applyPackages(id, importMap.imports, importMap.baseUrl) || urlResolved || throwBare(id, parentUrl);
+  return applyPackages(id, importMap.imports) || urlResolved || throwBare(id, parentUrl);
 }
 
 export function throwBare (id, parentUrl) {


### PR DESCRIPTION
This updates the scope handling in jspm to match the latest SystemJS 5.0.0 and es-module-shims in treating scopes as base-relative instead of scope-relative in the import maps.