### PR TITLE
docs: Fix simple typo, writeable -> writable

### DIFF
--- a/lib/install/source.js
+++ b/lib/install/source.js
@@ -234,7 +234,7 @@ async function fetchRemoteTarball(log, fetch, source, outDir) {
         // Unpack contents as a tar archive and save to targetDir
         new Promise((resolve, reject) => {
             stream.pipe(tar.extract(outDir, {
-                // all dirs and files should be readable and writeable
+                // all dirs and files should be readable and writable
                 dmode: 0o555,
                 fmode: 0o666,
                 strip: 1,


### PR DESCRIPTION
There is a small typo in lib/install/source.js.

Should read `writable` rather than `writeable`.

