### PR TITLE
Begin work on the downloadAll API

### DIFF
--- a/generator/.gitignore
+++ b/generator/.gitignore
@@ -3,3 +3,4 @@ node_modules
 lib
 yarn.lock
 .vscode
+fixtures

--- a/generator/test/api/download.test.js
+++ b/generator/test/api/download.test.js
@@ -1,0 +1,8 @@
+import { Generator } from '@jspm/generator';
+
+const generator = new Generator();
+await generator.install('react');
+await generator.install('dayjs');
+await generator.install('rxjs');
+
+await generator.downloadAll();

--- a/generator/test/api/download.test.js
+++ b/generator/test/api/download.test.js
@@ -1,8 +1,0 @@
-import { Generator } from '@jspm/generator';
-
-const generator = new Generator();
-await generator.install('react');
-await generator.install('dayjs');
-await generator.install('rxjs');
-
-await generator.downloadAll();

--- a/generator/test/api/downloadAll.test.js
+++ b/generator/test/api/downloadAll.test.js
@@ -1,14 +1,14 @@
 import { Generator } from '@jspm/generator';
 import assert from 'node:assert';
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const generator = new Generator();
-await generator.install('react');
-await generator.install('dayjs');
-await generator.install('rxjs');
-await generator.install('@angular/core');
-await generator.install('vue');
+await generator.install('react@19.1.0');
+await generator.install('dayjs@1.11.13');
+await generator.install('rxjs@7.8.2');
+await generator.install('@angular/core@20.0.4');
+await generator.install('vue@3.5.16');
 
 const map = await generator.downloadAll('./test/fixtures/deps');
 assert.deepEqual(map.toJSON(), {
@@ -30,3 +30,16 @@ assert.deepEqual(map.toJSON(), {
     './npm:rxjs@7.8.2/': { tslib: './npm:tslib@2.8.1/tslib.es6.mjs' }
   }
 });
+
+const files = await fs.readdir(path.resolve(import.meta.dirname, '../fixtures/deps'), {recursive: true});
+
+[
+  'npm:@angular/core@20.0.4/fesm2022/core.mjs',
+  'npm:dayjs@1.11.13/dayjs.min.js',
+  'npm:react@19.1.0/dev.index.js',
+  'npm:rxjs@7.8.2/dist/esm5/index.js',
+  'npm:tslib@2.8.1/tslib.es6.mjs',
+  'npm:vue@3.5.16/dist/vue.runtime.esm-browser.js'
+].forEach(file => {
+  assert.equal(files.includes(file), true)
+})

--- a/generator/test/api/downloadAll.test.js
+++ b/generator/test/api/downloadAll.test.js
@@ -1,0 +1,32 @@
+import { Generator } from '@jspm/generator';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const generator = new Generator();
+await generator.install('react');
+await generator.install('dayjs');
+await generator.install('rxjs');
+await generator.install('@angular/core');
+await generator.install('vue');
+
+const map = await generator.downloadAll('./test/fixtures/deps');
+assert.deepEqual(map.toJSON(), {
+  imports: {
+    react: './npm:react@19.1.0/dev.index.js',
+    dayjs: './npm:dayjs@1.11.13/dayjs.min.js',
+    rxjs: './npm:rxjs@7.8.2/dist/esm5/index.js',
+    '@angular/core': './npm:@angular/core@20.0.4/fesm2022/core.mjs',
+    vue: './npm:vue@3.5.16/dist/vue.runtime.esm-browser.js'
+  },
+  scopes: {
+    './npm:@angular/core@20.0.4/': {
+      '@angular/core/primitives/di': './npm:@angular/core@20.0.4/fesm2022/primitives/di.mjs',
+      '@angular/core/primitives/signals':
+        './npm:@angular/core@20.0.4/fesm2022/primitives/signals.mjs',
+      rxjs: './npm:rxjs@7.8.2/dist/esm5/index.js',
+      'rxjs/operators': './npm:rxjs@7.8.2/dist/esm5/operators/index.js'
+    },
+    './npm:rxjs@7.8.2/': { tslib: './npm:tslib@2.8.1/tslib.es6.mjs' }
+  }
+});


### PR DESCRIPTION
This is a draft, since I would prefer confirmation on the API before continuing. There was discussion in https://github.com/jspm/jspm/issues/2631 and https://github.com/jspm/jspm/issues/2605. I started the implementation with a `checkout()` api but the following comment was unclear to me:

```js
// Output is a map of URLs to local paths
// The import map returned then works against these local paths directly
```

The suggested return value seemed to be two things - a map of URLs to local paths, and an import map. The map of URLs to local paths seemed like it would only be used for download purposes, and exposed unnecessary internals.

@guybedford pls advise which API is most amenable to the jspm generator project.