### PR TITLE
fix: better handle build failures on JSPM by reporting CDN build issues where possible

### DIFF
--- a/cli/test/install-missing.test.ts
+++ b/cli/test/install-missing.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import { run } from './scenarios.ts';
+
+test('Install package with build failure', async () => {
+  await run({
+    files: new Map([
+      [
+        'package.json',
+        JSON.stringify({
+          name: 'test-package',
+          version: '1.0.0',
+          dependencies: {
+            'expo-camera': '16.1.11'
+          },
+          exports: {
+            '.': './index.js'
+          }
+        })
+      ],
+      ['index.js', 'import "expo-camera"']
+    ]),
+    commands: ['jspm install -o importmap.json'],
+    expectError: true
+  });
+});

--- a/generator/src/trace/resolver.ts
+++ b/generator/src/trace/resolver.ts
@@ -188,12 +188,13 @@ export class Resolver {
         }
         if (res.headers && !res.headers.get('Content-Type')?.match(/^application\/json(;|$)/)) {
           this.pcfgs[pkgUrl] = null;
-        } else
+        } else {
           try {
             this.pcfgs[pkgUrl] = await res.json();
           } catch (e) {
             this.pcfgs[pkgUrl] = null;
           }
+        }
       })();
     await this.pcfgPromises[pkgUrl];
     return this.pcfgs[pkgUrl];


### PR DESCRIPTION
This checks the `_error.log` file on the JSPM CDN when a package.json is not found for a package, allowing us to report packages that have build errors properly.

Note this still does not fix the problem of unbuilt packages reported as not found though.