### PR TITLE
feat: customResolver option for JSPM Generator

### DIFF
--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -760,6 +760,9 @@ export class Generator {
    *
    * By using link, we guarantee that the import map constructed is only for what is truly
    * needed and loaded. Dynamic imports that are statically analyzable are traced by link.
+   * 
+   * If a custom resolver is configured, it will be applied to the provided specifiers
+   * and all their dependencies during the linking process.
    */
   async link(
     specifier: string | string[],
@@ -1029,6 +1032,9 @@ export class Generator {
    * // Install all exports of the package, based on enumerating all the package export subpaths.
    * await generator.install({ alias: 'mypkg', target: './packages/local-pkg', subpaths: true });
    * ```
+   * 
+   * Will respect {@link GeneratorOptions.customResolver} for dependency specifier resolution. If requiring
+   * a {@link GeneratorOptions.customResolver} to apply at the top-level, use {@link Generator.link} instead.
    */
   async install(install: string | Install | (string | Install)[], mode?: InstallMode);
   async install(mode?: InstallMode);

--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -366,6 +366,42 @@ export interface GeneratorOptions {
   };
 
   /**
+   * Custom async resolver function for intercepting resolution operations.
+   *
+   * When provided, this function will be called first for all resolution operations.
+   * If it returns a string URL, that will be used as the resolved module and persisted
+   * in the import map. If it returns undefined, normal resolution continues.
+   *
+   * @param specifier The module specifier being resolved
+   * @param parentUrl The URL of the parent module
+   * @param context Additional context including environment and other metadata
+   * @returns A resolved URL string or undefined to continue with default resolution
+   *
+   * @example
+   * ```js
+   * const generator = new Generator({
+   *   customResolver: async (specifier, parentUrl, context) => {
+   *     if (specifier === 'my-custom-lib') {
+   *       return 'https://cdn.example.com/my-custom-lib@1.0.0/index.js';
+   *     }
+   *     return undefined;
+   *   }
+   * });
+   * ```
+   */
+  customResolver?: (
+    specifier: string,
+    parentUrl: string,
+    context: {
+      parentPkgUrl: string;
+      env?: string[];
+      installMode: any;
+      toplevel: boolean;
+      [key: string]: any;
+    }
+  ) => string | undefined | Promise<string | undefined>;
+
+  /**
    * @default true
    *
    * Whether to flatten import map scopes into domain-groupings.
@@ -561,6 +597,7 @@ export class Generator {
     fetchRetries,
     providerConfig = {},
     preserveSymlinks,
+    customResolver,
     flattenScopes = true,
     combineSubpaths = true
   }: GeneratorOptions = {}) {
@@ -639,7 +676,8 @@ export class Generator {
         providers,
         ignore,
         resolutions,
-        commonJS
+        commonJS,
+        customResolver
       },
       log,
       resolver

--- a/generator/src/providers/jspm.ts
+++ b/generator/src/providers/jspm.ts
@@ -54,7 +54,10 @@ export async function pkgToUrl(pkg: ExactPackage, layer = 'default'): Promise<`$
   return `${layer === 'system' ? systemCdnUrl : gaUrl}${pkgToStr(pkg)}/`;
 }
 
-export async function getPackageConfig(this: ProviderContext, pkgUrl: string): Promise<PackageConfig | null> {
+export async function getPackageConfig(
+  this: ProviderContext,
+  pkgUrl: string
+): Promise<PackageConfig | null> {
   try {
     var res = await fetch(`${pkgUrl}package.json`, this.fetchOpts);
   } catch (e) {
@@ -87,7 +90,7 @@ export async function getPackageConfig(this: ProviderContext, pkgUrl: string): P
     return null;
   } else {
     try {
-      return await res.json() as PackageConfig;
+      return (await res.json()) as PackageConfig;
     } catch (e) {
       return null;
     }

--- a/generator/test/api/custom-resolver.test.js
+++ b/generator/test/api/custom-resolver.test.js
@@ -1,0 +1,161 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+{
+  const customMappings = {
+    'my-custom-lib': 'https://ga.jspm.io/npm:lodash@4.17.21/lodash.js',
+    'another-lib': 'https://ga.jspm.io/npm:semver@7.5.4/index.js'
+  };
+
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'jspm.io',
+    env: ['production', 'browser'],
+    customResolver: async (specifier, parentUrl, context) => {
+      if (customMappings[specifier]) {
+        return customMappings[specifier];
+      }
+      return undefined;
+    }
+  });
+
+  await generator.link(['my-custom-lib', 'another-lib']);
+  await generator.install('react@16');
+  const json = generator.getMap();
+
+  assert.strictEqual(
+    json.imports['my-custom-lib'],
+    'https://ga.jspm.io/npm:lodash@4.17.21/lodash.js'
+  );
+  assert.strictEqual(json.imports['another-lib'], 'https://ga.jspm.io/npm:semver@7.5.4/index.js');
+
+  assert.strictEqual(json.imports.react, 'https://ga.jspm.io/npm:react@16.14.0/index.js');
+}
+
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'jspm.io',
+    env: ['production', 'browser'],
+    customResolver: async (specifier, parentUrl, context) => {
+      return undefined;
+    }
+  });
+
+  await generator.install('react@17');
+  const json = generator.getMap();
+
+  assert.strictEqual(json.imports.react, 'https://ga.jspm.io/npm:react@17.0.2/index.js');
+}
+
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'jspm.io',
+    env: ['development', 'browser'],
+    customResolver: async (specifier, parentUrl, context) => {
+      if (specifier === 'debug-lib' && context.env?.includes('development')) {
+        return 'https://ga.jspm.io/npm:debug@4.3.4/src/browser.js';
+      }
+      if (specifier === 'debug-lib' && context.env?.includes('production')) {
+        return 'https://ga.jspm.io/npm:debug@4.3.4/src/index.js';
+      }
+      return undefined;
+    }
+  });
+
+  await generator.link('debug-lib');
+  const json = generator.getMap();
+
+  assert.strictEqual(
+    json.imports['debug-lib'],
+    'https://ga.jspm.io/npm:debug@4.3.4/src/browser.js'
+  );
+}
+
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'jspm.io',
+    env: ['production', 'browser'],
+    customResolver: async (specifier, parentUrl, context) => {
+      if (specifier === 'dep') {
+        return './local/assets/file.js';
+      }
+      return undefined;
+    }
+  });
+
+  await generator.install({ target: './local/pkg', subpath: './withdep' });
+  const json = generator.getMap();
+
+  assert.strictEqual(json.imports['localpkg/withdep'], './local/pkg/b.js');
+  assert.strictEqual(json.scopes['./local/pkg/'].dep, './local/assets/file.js');
+}
+
+{
+  let resolverCalls = [];
+
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'jspm.io',
+    env: ['production', 'browser'],
+    customResolver: async (specifier, parentUrl, context) => {
+      resolverCalls.push({ specifier, parentUrl });
+
+      if (specifier === 'my-lib') {
+        return 'https://ga.jspm.io/npm:ms@2.1.3/index.js';
+      }
+      return undefined;
+    }
+  });
+
+  await generator.link('my-lib');
+
+  assert(resolverCalls.some(call => call.specifier === 'my-lib'));
+}
+
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'jspm.io',
+    env: ['production', 'browser'],
+    customResolver: async (specifier, parentUrl, context) => {
+      if (specifier === 'error-pkg') {
+        throw new Error('Custom resolver error');
+      }
+      return undefined;
+    }
+  });
+
+  let errorThrown = false;
+  try {
+    await generator.link('error-pkg');
+  } catch (e) {
+    errorThrown = true;
+    assert(e.message.includes('Custom resolver error'));
+  }
+  assert(errorThrown, 'Expected error to be thrown');
+}
+
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'jspm.io',
+    env: ['production', 'browser'],
+    customResolver: async (specifier, parentUrl, context) => {
+      if (specifier === '@myorg/private-pkg') {
+        return 'https://ga.jspm.io/npm:@babel/core@7.24.7/lib/index.js';
+      }
+      return undefined;
+    }
+  });
+
+  await generator.link('@myorg/private-pkg');
+  const json = generator.getMap();
+
+  assert.strictEqual(
+    json.imports['@myorg/private-pkg'],
+    'https://ga.jspm.io/npm:@babel/core@7.24.7/lib/index.js'
+  );
+}


### PR DESCRIPTION
This adds a new customResolver option to the JSPM Generator that allows intercepting and customizing module resolution operations. When provided, the custom resolver function is called first for all resolution operations, enabling use cases like private package mappings, environment-specific resolutions, and custom CDN routing.

```js
  const generator = new Generator({
    customResolver: async (specifier, parentUrl, context) => {
      if (specifier === 'my-private-lib') {
        return 'https://private-cdn.example.com/my-private-lib@1.0.0/index.js';
      }
      return undefined; // fallback to normal resolution
    }
  });
```

The custom resolver receives the module specifier, parent URL, and context, and can return a resolved URL string or undefined to continue with default resolution. The resolved mappings respect package boundaries and are properly scoped in the import map.