### PR TITLE
fix: link failure with no pins

### DIFF
--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -840,7 +840,7 @@ export class Generator {
       throw e;
     } finally {
       const { map, staticDeps, dynamicDeps } = await this.traceMap.extractMap(
-        this.traceMap.pins || pins,
+        this.traceMap.pins || pins || [],
         this.integrity,
         !this.scopedLink
       );


### PR DESCRIPTION
Fixes a bug where link fails and there are no pins masking the underlying error.