### PR TITLE
feat: support non-resolving providers

### DIFF
--- a/generator/chompfile.toml
+++ b/generator/chompfile.toml
@@ -138,6 +138,16 @@ deps = [
 run = 'node -C source --enable-source-maps $DEP'
 
 [[task]]
+name = 'integration-debug:#'
+env.JSPM_GENERATOR_LOG = "1"
+deps = [
+    'test/##.test.js',
+    'lib',
+]
+run = 'node -C source --enable-source-maps $DEP'
+
+
+[[task]]
 name = 'test:browser'
 deps = [
     'build:ts',

--- a/generator/test/providers/customnonresolving.test.js
+++ b/generator/test/providers/customnonresolving.test.js
@@ -1,0 +1,21 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  customProviders: {
+    custom: {
+      ownsUrl (url) {
+        return url.startsWith('https://framerusercontent.com/') || url.startsWith('https://framerusercontent.dev/');
+      },
+      // Framer does not support package.json config files currently for customizing package resolutions with exports
+      // or imports, or for supporting dependency version ranges
+      getPackageConfig (url) {
+        return null;
+      }
+    }
+  }
+});
+
+await generator.link('https://framerusercontent.com/modules/hbDCoHjvQqMyIH6I6akS/JpP37lZcTYRA5qoY1Tdv/Qhb7p35zo.js');
+const map = generator.getMap();
+assert.ok(map.imports.framer);


### PR DESCRIPTION
This adds support for non-resolving providers that don't support a registry-based versioned installation, but still allows providers to define behaviours on URLs and own URLs. This can be useful for custom package configuration paths / dependency management / etc.

The implementation works by making `parseUrlPkg`, `pkgToUrl` and `resolveLatestTarget` package hooks optional, throwing for an install of `providerName:pkg` while allowing `jspm link https://provider.com/foo.js` to get provider hooks applied, with referencing defined through the `ownsUrl` hook.