### PR TITLE
fix: skip package.json check on jspm.io root

### DIFF
--- a/generator/src/providers/jspm.ts
+++ b/generator/src/providers/jspm.ts
@@ -58,6 +58,8 @@ export async function getPackageConfig(
   this: ProviderContext,
   pkgUrl: string
 ): Promise<PackageConfig | null> {
+  if (pkgUrl === gaUrl)
+    return null;
   try {
     var res = await fetch(`${pkgUrl}package.json`, this.fetchOpts);
   } catch (e) {


### PR DESCRIPTION
It's possible for generation operations to check `https://ga.jspm.io/package.json` which will always be a not found. This hard-codes that case in the JSPM provider to avoid the unnecessary fetch.