### PR TITLE
fix: htmlInject integrity loading

### DIFF
--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -1020,7 +1020,7 @@ export class Generator {
           integrity
             ? ` integrity="${await getIntegrity(
                 new Uint8Array(
-                  await (await fetch(dep, this.traceMap.resolver.fetchOpts)).arrayBuffer()
+                  await (await fetch(new URL(dep, this.baseUrl).href, this.traceMap.resolver.fetchOpts)).arrayBuffer()
                 )
               )}"`
             : ''


### PR DESCRIPTION
Fixes a bug with `generator.htmlInject` preloading URL resolution.