### PR TITLE
builtin refactor, lock extraction performance

### DIFF
--- a/generator/src/install/lock.ts
+++ b/generator/src/install/lock.ts
@@ -352,7 +352,7 @@ export async function extractLockConstraintsAndMap(
   const pkgUrls = new Set<string>();
   const promises: Promise<void>[] = [];
 
-  for (const key of Object.keys(map.imports || {})) {
+  for (let key of Object.keys(map.imports || {})) {
     promises.push(
       (async () => {
         if (isPlain(key)) {

--- a/generator/src/providers/deno.ts
+++ b/generator/src/providers/deno.ts
@@ -10,10 +10,6 @@ const stdlibUrl = 'https://deno.land/std';
 
 let denoStdVersion;
 
-export function isBuiltin(specifier: string): boolean {
-  return specifier.startsWith('deno:');
-}
-
 export function resolveBuiltin(
   specifier: string,
   env: string[]

--- a/generator/src/providers/deno.ts
+++ b/generator/src/providers/deno.ts
@@ -2,7 +2,7 @@ import type { ExactPackage, LatestPackageTarget, PackageConfig } from '../instal
 import { SemverRange } from 'sver';
 // @ts-ignore
 import { fetch } from '../common/fetch.js';
-import type { Install } from '../generator.js';
+import type { PackageTarget } from '../generator.js';
 import type { ProviderContext } from './index.js';
 
 const cdnUrl = 'https://deno.land/x/';
@@ -10,7 +10,14 @@ const stdlibUrl = 'https://deno.land/std';
 
 let denoStdVersion;
 
-export function resolveBuiltin(specifier: string, env: string[]): string | Install | undefined {
+export function isBuiltin(specifier: string): boolean {
+  return specifier.startsWith('deno:');
+}
+
+export function resolveBuiltin(
+  specifier: string,
+  env: string[]
+): string | { target: PackageTarget; subpath: '.' | `./${string}` } | undefined {
   // Bare npm:XXX imports are supported by Deno:
   if (env.includes('deno') && specifier.startsWith('npm:')) return specifier;
 
@@ -25,17 +32,13 @@ export function resolveBuiltin(specifier: string, env: string[]): string | Insta
       subpath = `./${name.slice(slashIndex + 1)}`;
     }
     return {
-      alias,
-      subpath,
       target: {
-        pkgTarget: {
-          registry: 'deno',
-          name: 'std',
-          ranges: [new SemverRange('*')],
-          unstable: true
-        },
-        installSubpath: `./${slashIndex === -1 ? name : name.slice(0, slashIndex)}`
-      }
+        registry: 'deno',
+        name: 'std',
+        ranges: [new SemverRange('*')],
+        unstable: true
+      },
+      subpath
     };
   }
 }
@@ -156,7 +159,7 @@ const vCache = {};
 
 export function parseUrlPkg(
   url: string
-): { pkg: ExactPackage; subpath: `./${string}` | null; layer: string } | undefined {
+): { pkg: ExactPackage; builtin: null | string; layer: string } | undefined {
   let subpath = null;
   if (url.startsWith(stdlibUrl) && url[stdlibUrl.length] === '@') {
     const version = url.slice(stdlibUrl.length + 1, url.indexOf('/', stdlibUrl.length + 1));
@@ -167,7 +170,7 @@ export function parseUrlPkg(
     return {
       pkg: { registry: 'deno', name: 'std', version },
       layer: 'default',
-      subpath: `./${name}${subpath ? (`./${subpath}/mod.ts` as `./${string}`) : ''}`
+      builtin: `deno:${name}/${subpath}`
     };
   } else if (url.startsWith(cdnUrl)) {
     const path = url.slice(cdnUrl.length);
@@ -181,7 +184,7 @@ export function parseUrlPkg(
     );
     return {
       pkg: { registry: 'denoland', name, version },
-      subpath: null,
+      builtin: null,
       layer: 'default'
     };
   }

--- a/generator/src/providers/index.ts
+++ b/generator/src/providers/index.ts
@@ -236,7 +236,11 @@ export class ProviderManager {
    * @param layer Layer to use
    * @returns URL for the package
    */
-  pkgToUrl(pkg: ExactPackage, provider: string, layer = 'default'): `${string}/` | Promise<`${string}/`> {
+  pkgToUrl(
+    pkg: ExactPackage,
+    provider: string,
+    layer = 'default'
+  ): `${string}/` | Promise<`${string}/`> {
     const providerInstance = this.#getProvider(provider);
     if (!providerInstance.pkgToUrl)
       throw new JspmError(`Provider ${provider} does not provide versioned package support`);
@@ -302,18 +306,6 @@ export class ProviderManager {
       await walk(pkgUrl, pkgUrl);
       return fileList;
     }
-  }
-
-  /**
-   * Determine with the specifier is a builtin specifier
-   */
-  isBuiltin(specifier: string): boolean {
-    for (const [name, provider] of Object.entries(this.providers).reverse()) {
-      if (!provider.isBuiltin) continue;
-      const context = this.#getProviderContext(name);
-      if (provider.isBuiltin.call(context, specifier)) return true;
-    }
-    return false;
   }
 
   /**

--- a/generator/src/providers/index.ts
+++ b/generator/src/providers/index.ts
@@ -12,7 +12,7 @@ import {
   PackageTarget
 } from '../install/package.js';
 import { Resolver } from '../trace/resolver.js';
-import { Install } from '../generator.js';
+import { Install, InstallTarget } from '../generator.js';
 import { JspmError } from '../common/err.js';
 import { Log } from '../common/log.js';
 import { PackageProvider } from '../install/installer.js';
@@ -24,7 +24,7 @@ export interface Provider {
   parseUrlPkg?(
     this: ProviderContext,
     url: string
-  ): ExactPackage | { pkg: ExactPackage; subpath: `./${string}` | null; layer: string } | null;
+  ): ExactPackage | { pkg: ExactPackage; layer: string; builtin: string | null } | null;
 
   pkgToUrl?(
     this: ProviderContext,
@@ -42,7 +42,13 @@ export interface Provider {
 
   ownsUrl?(this: ProviderContext, url: string): boolean;
 
-  resolveBuiltin?(this: ProviderContext, specifier: string, env: string[]): string | Install | null;
+  isBuiltin?(this: ProviderContext, specifier: string): boolean;
+
+  resolveBuiltin?(
+    this: ProviderContext,
+    specifier: string,
+    env: string[]
+  ): string | { target: PackageTarget; subpath: '.' | `./${string}` } | null;
 
   getPackageConfig?(this: ProviderContext, pkgUrl: string): Promise<PackageConfig | null>;
 
@@ -202,7 +208,7 @@ export class ProviderManager {
   parseUrlPkg(url: string): {
     pkg: ExactPackage;
     source: { provider: string; layer: string };
-    subpath: `./${string}` | null;
+    builtin: string | null;
   } | null {
     for (const provider of Object.keys(this.providers).reverse()) {
       const providerInstance = this.providers[provider];
@@ -216,7 +222,7 @@ export class ProviderManager {
             provider,
             layer: 'layer' in result ? result.layer : 'default'
           },
-          subpath: 'subpath' in result ? result.subpath : null
+          builtin: 'builtin' in result ? result.builtin : null
         };
     }
     return null;
@@ -230,11 +236,7 @@ export class ProviderManager {
    * @param layer Layer to use
    * @returns URL for the package
    */
-  pkgToUrl(
-    pkg: ExactPackage,
-    provider: string,
-    layer = 'default'
-  ): `${string}/` | Promise<`${string}/`> {
+  pkgToUrl(pkg: ExactPackage, provider: string, layer = 'default'): `${string}/` | Promise<`${string}/`> {
     const providerInstance = this.#getProvider(provider);
     if (!providerInstance.pkgToUrl)
       throw new JspmError(`Provider ${provider} does not provide versioned package support`);
@@ -303,12 +305,27 @@ export class ProviderManager {
   }
 
   /**
+   * Determine with the specifier is a builtin specifier
+   */
+  isBuiltin(specifier: string): boolean {
+    for (const [name, provider] of Object.entries(this.providers).reverse()) {
+      if (!provider.isBuiltin) continue;
+      const context = this.#getProviderContext(name);
+      if (provider.isBuiltin.call(context, specifier)) return true;
+    }
+    return false;
+  }
+
+  /**
    * Resolve a builtin module
    *
    * @param specifier Module specifier
-   * @returns Resolved string, install object, or undefined if not resolvable
+   * @returns Resolved string, install target and exports subpath, or undefined if not resolvable
    */
-  resolveBuiltin(specifier: string, env: string[]): string | Install | undefined {
+  resolveBuiltin(
+    specifier: string,
+    env: string[]
+  ): string | { target: PackageTarget; subpath: '.' | `./${string}` } | undefined {
     for (const [name, provider] of Object.entries(this.providers).reverse()) {
       if (!provider.resolveBuiltin) continue;
       const context = this.#getProviderContext(name);

--- a/generator/src/providers/jspm.ts
+++ b/generator/src/providers/jspm.ts
@@ -109,7 +109,7 @@ export function configure(config: any) {
 const exactPkgRegEx = /^(([a-z]+):)?((?:@[^/\\%@]+\/)?[^./\\%@][^/\\%@]*)@([^\/]+)(\/.*)?$/;
 
 export function parseUrlPkg(url: string) {
-  let subpath = null;
+  let builtin = null;
   let layer: string;
   if (url.startsWith(gaUrl)) layer = 'default';
   else if (url.startsWith(systemCdnUrl)) layer = 'system';
@@ -118,11 +118,10 @@ export function parseUrlPkg(url: string) {
     url.slice((layer === 'default' ? gaUrl : systemCdnUrl).length).match(exactPkgRegEx) || [];
   if (registry && name && version) {
     if (registry === 'npm' && name === '@jspm/core' && url.includes('/nodelibs/')) {
-      subpath = `./nodelibs/${url.slice(url.indexOf('/nodelibs/') + 10).split('/')[1]}`;
-      if (subpath && subpath.endsWith('.js')) subpath = subpath.slice(0, -3);
-      else subpath = null;
+      builtin = url.slice(url.indexOf('/nodelibs/') + 10);
+      if (builtin.endsWith('.js')) builtin = builtin.slice(0, -3);
     }
-    return { pkg: { registry, name, version }, layer, subpath };
+    return { pkg: { registry, name, version }, layer, builtin };
   }
 }
 
@@ -482,6 +481,7 @@ export async function publish(
       // for mutable packages, we retain the no-cache status for 30 seconds (for testing)
       // 'x-no-cache-duration': 30
     },
+    // @ts-ignore
     body: tarball
   });
 

--- a/generator/src/providers/node.ts
+++ b/generator/src/providers/node.ts
@@ -83,10 +83,6 @@ export function pkgToUrl(pkg: ExactPackage, layer: string): `${string}/` {
   return `node:${pkg.name}/`;
 }
 
-export function isBuiltin(specifier: string): boolean {
-  return specifier.startsWith('node:') ? true : nodeBuiltinSet.has(specifier);
-}
-
 export function resolveBuiltin(
   specifier: string,
   env: string[]

--- a/generator/src/providers/node.ts
+++ b/generator/src/providers/node.ts
@@ -1,10 +1,14 @@
-import { ExactPackage, LatestPackageTarget, PackageConfig } from '../install/package.js';
+import {
+  ExactPackage,
+  LatestPackageTarget,
+  PackageConfig,
+  PackageTarget
+} from '../install/package.js';
 import { SemverRange } from 'sver';
 import {
   resolveLatestTarget as resolveLatestTargetJspm,
   pkgToUrl as pkgToUrlJspm
 } from './jspm.js';
-import { Install } from '../generator.js';
 import { Resolver } from '../trace/resolver.js';
 
 export const nodeBuiltinSet = new Set<string>([
@@ -79,7 +83,14 @@ export function pkgToUrl(pkg: ExactPackage, layer: string): `${string}/` {
   return `node:${pkg.name}/`;
 }
 
-export function resolveBuiltin(specifier: string, env: string[]): string | Install | undefined {
+export function isBuiltin(specifier: string): boolean {
+  return specifier.startsWith('node:') ? true : nodeBuiltinSet.has(specifier);
+}
+
+export function resolveBuiltin(
+  specifier: string,
+  env: string[]
+): string | { target: PackageTarget; subpath: `./${string}` } | undefined {
   let builtin = specifier.startsWith('node:')
     ? specifier.slice(5)
     : nodeBuiltinSet.has(specifier)
@@ -100,15 +111,12 @@ export function resolveBuiltin(specifier: string, env: string[]): string | Insta
 
   return {
     target: {
-      pkgTarget: {
-        registry: 'npm',
-        name: '@jspm/core',
-        ranges: [new SemverRange('*')],
-        unstable: true
-      },
-      installSubpath: `./nodelibs/${builtin}`
+      registry: 'npm',
+      name: '@jspm/core',
+      ranges: [new SemverRange('*')],
+      unstable: true
     },
-    alias: builtin
+    subpath: `./nodelibs/${builtin}`
   };
 }
 

--- a/generator/src/providers/nodemodules.ts
+++ b/generator/src/providers/nodemodules.ts
@@ -61,7 +61,7 @@ export function createProvider(baseUrl: string, ownsBaseUrl: boolean): Provider 
           registry: 'node_modules',
           version: encodeBase64(pkgUrl)
         },
-        subpath: subpath === './' ? null : (subpath as `./${string}`),
+        builtin: subpath === './' ? null : (subpath as `./${string}`),
         layer: 'default'
       };
     }

--- a/generator/test/perf/perf.test.js
+++ b/generator/test/perf/perf.test.js
@@ -11,7 +11,8 @@ const largeInstallSet = await (
   const generator = new Generator({
     defaultProvider: 'jspm.io',
     resolutions: {
-      react: '16.14.0'
+      react: '16.14.0',
+      porto: '0.0.93'
     }
   });
   const installs = Object.entries(largeInstallSet).map(([name, versionRange]) => ({
@@ -25,7 +26,8 @@ const largeInstallSet = await (
   const generator = new Generator({
     defaultProvider: 'jspm.io',
     resolutions: {
-      react: '16.14.0'
+      react: '16.14.0',
+      porto: '0.0.93'
     }
   });
 


### PR DESCRIPTION
This implements a refactoring and performance optimization that avoids the need to do upfront package.json configuration fetching for all packages in the importmap and scopes upfront, instead only loading these as needed.

This is a major performance improvement for small import map operations on larger maps.

To achieve this, the builtin module and URL install systems had to be refactored to no longer rely on the somewhat fragile subpath install feature - previously when resolving a builtin like `fs` we would treat this as `{ target: '@jspm/core', subpath: './nodelibs/fs' }` - that is, a package could map inside of another package. This functionality put pressure on the lock file system to then decompose this, the decomposition of which then caused unnecessary package manifest checking to try and disambiguate these cases.

Instead, builtins now resolve their subpaths separately to this subpath generalization with URL installs, and builtins are checked early as well - this is strictly a breaking change in that it is no longer possible to remap `fs` using "dependencies", since it will always go down the builtin path, but it seems like it should not be widely relied on since overriding resolutions for Node.js builtins is generally not a pattern to be relied upon.

Then, for lock reconstruction, we now reconstruct the lock without resolving all internal subpaths to distinguish between correct and incorrect mappings, and instead just trusting that the resolutions are correct. This is also formally a breaking change, but again, these aren't behaviours which are likely widely relied upon given that it is so brittle to rely on individual package maps to remain for custom edits. This also aligns more closely with the way JSPM started as treating import maps as user manifests, but now treats them more as lockfiles that are not about retaining fine-grained human edits to internal version resolutions, apart from versioning changes.