### PR TITLE
perf: optimize internal routines with caching

### DIFF
--- a/cli/test/importmap-fallback.test.ts
+++ b/cli/test/importmap-fallback.test.ts
@@ -25,7 +25,7 @@ test('Support importmap.json when both exist', async () => {
 
       const map = JSON.parse(files.get('importmap.json')!);
       assert(
-        map.imports.react === 'https://cdn.jsdelivr.net/npm/react@19.2.1/index.js',
+        map.imports.react === 'https://cdn.jsdelivr.net/npm/react@19.2.3/index.js',
         'react should be preserved in importmap.js'
       );
       assert(!map.imports.jquery, 'jquery should be pruned from importmap.js');

--- a/cli/test/install.test.ts
+++ b/cli/test/install.test.ts
@@ -48,8 +48,8 @@ test('Local install', async () => {
     cwd: 'pkg2',
     validationFn: async (files: Map<string, string>) => {
       const map: IImportMap = JSON.parse(files.get('pkg2/importmap.json')!);
-      assert.ok(map.scopes?.['https://cdn.jsdelivr.net/npm/lit-element@4.2.1/']);
-      assert.ok(map.scopes?.['https://cdn.jsdelivr.net/npm/lit@3.3.1/']);
+      assert.ok(map.scopes?.['https://cdn.jsdelivr.net/npm/lit-element@4.2.2/']);
+      assert.ok(map.scopes?.['https://cdn.jsdelivr.net/npm/lit@3.3.2/']);
     }
   });
 });

--- a/generator/src/common/package.ts
+++ b/generator/src/common/package.ts
@@ -29,10 +29,20 @@ export function getMapMatch<T = any>(
   return bestMatch;
 }
 
-export function allDotKeys(exports: Record<string, any>) {
+// Cache for allDotKeys results - same exports object is checked multiple times
+const allDotKeysCache = new WeakMap<Record<string, any>, boolean>();
+
+export function allDotKeys(exports: Record<string, any>): boolean {
+  const cached = allDotKeysCache.get(exports);
+  if (cached !== undefined) return cached;
+
   for (let p in exports) {
-    if (p[0] !== '.') return false;
+    if (p[0] !== '.') {
+      allDotKeysCache.set(exports, false);
+      return false;
+    }
   }
+  allDotKeysCache.set(exports, true);
   return true;
 }
 

--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -365,6 +365,13 @@ export interface GeneratorOptions {
   integrity?: boolean;
 
   /**
+   * Whether to include "dependencyCache" field in the import map.
+   * When enabled, the import map will include direct static and dynamic
+   * dependencies for each module URL in the final pruned graph.
+   */
+  dependencyCache?: boolean;
+
+  /**
    * The number of fetch retries to attempt for request failures.
    * Defaults to 3.
    */

--- a/generator/src/install/installer.ts
+++ b/generator/src/install/installer.ts
@@ -539,21 +539,10 @@ export class Installer {
         this.constraints.secondary[pkgScope] || Object.create(null))[name] = target;
     }
 
-    // Maintain the index incrementally
-    if (this._constraintsByKey) {
-      const key = `${target.registry}:${target.name}`;
-      const constraint: PackageConstraint = {
-        alias: name,
-        pkgScope,
-        ranges: target.ranges
-      };
-      const list = this._constraintsByKey.get(key);
-      if (list) {
-        list.push(constraint);
-      } else {
-        this._constraintsByKey.set(key, [constraint]);
-      }
-    }
+    // Invalidate the index - it will be rebuilt lazily on next access
+    // This is simpler and safer than trying to maintain it incrementally
+    // since setConstraint can update existing constraints
+    this._constraintsByKey = null;
   }
 
   // Get constraints for a package, building index lazily

--- a/generator/src/install/installer.ts
+++ b/generator/src/install/installer.ts
@@ -3,14 +3,11 @@ import { Log } from '../common/log.js';
 import { registryProviders } from '../providers/index.js';
 import { Resolver } from '../trace/resolver.js';
 import {
-  getConstraintFor,
   getFlattenedResolution,
   getResolution,
   InstalledResolution,
   LockResolutions,
   PackageConstraint,
-  setConstraint,
-  setResolution,
   VersionConstraints
 } from './lock.js';
 import { ExactPackage, newPackageTarget, PackageTarget } from './package.js';
@@ -104,6 +101,12 @@ export class Installer {
   resolutions: Record<string, string>;
   log: Log;
   resolver: Resolver;
+  // Cached set of package URLs - maintained incrementally for performance
+  private _pkgUrls: Set<string> | null = null;
+  // Index of packages by registry:name for fast lookup in getBestExistingMatch
+  private _pkgsByKey: Map<string, ExactPackage[]> | null = null;
+  // Index of constraints by registry:name for fast lookup
+  private _constraintsByKey: Map<string, PackageConstraint[]> | null = null;
 
   constructor(baseUrl: `${string}/`, opts: InstallerOptions, log: Log, resolver: Resolver) {
     this.log = log;
@@ -200,7 +203,7 @@ export class Installer {
 
       this.log('installer/installTarget', `${pkgName} ${pkgScope} -> ${installHref} (URL)`);
 
-      this.newInstalls = setResolution(this.installs, pkgName, installUrl, pkgScope);
+      this.newInstalls = this.setResolution(pkgName, installUrl, pkgScope);
       return { installUrl };
     }
 
@@ -216,8 +219,8 @@ export class Installer {
           `${pkgName} ${pkgScope} -> ${JSON.stringify(pkg)} (existing match)`
         );
         const installUrl = await this.resolver.pm.pkgToUrl(pkg, provider.provider, provider.layer);
-        this.newInstalls = setResolution(this.installs, pkgName, installUrl, pkgScope);
-        setConstraint(this.constraints, pkgName, pkgTarget, pkgScope);
+        this.newInstalls = this.setResolution(pkgName, installUrl, pkgScope);
+        this.setConstraint(pkgName, pkgTarget, pkgScope);
         return { installUrl };
       }
     }
@@ -229,7 +232,7 @@ export class Installer {
       this.resolver
     );
     const pkgUrl = await this.resolver.pm.pkgToUrl(latestPkg, provider.provider, provider.layer);
-    const installed = getConstraintFor(latestPkg.name, latestPkg.registry, this.constraints);
+    const installed = this.getConstraintFor(latestPkg.name, latestPkg.registry);
 
     // If this is a secondary install, then we ideally want to upgrade all
     // existing locks on this package to latest and use that. If there's a
@@ -249,8 +252,8 @@ export class Installer {
           `${pkgName} ${pkgScope} -> ${JSON.stringify(latestPkg)} (existing match not latest)`
         );
         const installUrl = await this.resolver.pm.pkgToUrl(pkg, provider.provider, provider.layer);
-        this.newInstalls = setResolution(this.installs, pkgName, installUrl, pkgScope);
-        setConstraint(this.constraints, pkgName, pkgTarget, pkgScope);
+        this.newInstalls = this.setResolution(pkgName, installUrl, pkgScope);
+        this.setConstraint(pkgName, pkgTarget, pkgScope);
         return { installUrl };
       }
     }
@@ -258,8 +261,8 @@ export class Installer {
     // Otherwise we install latest and make an attempt to upgrade any existing
     // locks that are compatible to the latest version:
     this.log('installer/installTarget', `${pkgName} ${pkgScope} -> ${pkgUrl} (latest)`);
-    this.newInstalls = setResolution(this.installs, pkgName, pkgUrl, pkgScope);
-    setConstraint(this.constraints, pkgName, pkgTarget, pkgScope);
+    this.newInstalls = this.setResolution(pkgName, pkgUrl, pkgScope);
+    this.setConstraint(pkgName, pkgTarget, pkgScope);
     if (mode !== 'freeze') this.upgradeSupportedTo(latestPkg, pkgUrl, installed);
     return { installUrl: pkgUrl };
   }
@@ -412,12 +415,7 @@ export class Installer {
         (mode === 'freeze' ||
           (await this.inRange(flattenedResolution.installUrl, pjsonTarget.pkgTarget)))
       ) {
-        this.newInstalls = setResolution(
-          this.installs,
-          pkgName,
-          flattenedResolution.installUrl,
-          pkgScope
-        );
+        this.newInstalls = this.setResolution(pkgName, flattenedResolution.installUrl, pkgScope);
         return flattenedResolution;
       }
     }
@@ -456,8 +454,10 @@ export class Installer {
     return { installUrl };
   }
 
-  // Note: maintain this live instead of recomputing
-  private get pkgUrls() {
+  // Cached set of package URLs - built once then maintained incrementally
+  private get pkgUrls(): Set<string> {
+    if (this._pkgUrls) return this._pkgUrls;
+
     const pkgUrls = new Set<string>();
     for (const pkgUrl of Object.values(this.installs.primary)) {
       pkgUrls.add(pkgUrl.installUrl);
@@ -474,20 +474,160 @@ export class Installer {
         pkgUrls.add(installUrl);
       }
     }
+    this._pkgUrls = pkgUrls;
     return pkgUrls;
   }
 
-  private async getBestExistingMatch(matchPkg: PackageTarget): Promise<ExactPackage | null> {
-    let bestMatch: ExactPackage | null = null;
+  // Set resolution and maintain caches incrementally
+  private setResolution(
+    name: string,
+    installUrl: `${string}/`,
+    pkgScope: `${string}/` | null = null
+  ): boolean {
+    let changed: boolean;
+    if (pkgScope === null) {
+      const existing = this.installs.primary[name];
+      if (existing && existing.installUrl === installUrl) {
+        changed = false;
+      } else {
+        this.installs.primary[name] = { installUrl };
+        changed = true;
+      }
+    } else {
+      this.installs.secondary[pkgScope] = this.installs.secondary[pkgScope] || {};
+      const existing = this.installs.secondary[pkgScope][name];
+      if (existing && existing.installUrl === installUrl) {
+        changed = false;
+      } else {
+        this.installs.secondary[pkgScope][name] = { installUrl };
+        changed = true;
+      }
+    }
+    // Maintain the pkgUrls cache incrementally
+    if (this._pkgUrls) {
+      this._pkgUrls.add(installUrl);
+    }
+    // Maintain the pkgsByKey index incrementally
+    if (this._pkgsByKey && changed) {
+      const parsed = this.resolver.pm.parseUrlPkg(installUrl);
+      if (parsed) {
+        const key = `${parsed.pkg.registry}:${parsed.pkg.name}`;
+        const list = this._pkgsByKey.get(key);
+        if (list) {
+          // Check if this exact version is already in the list
+          if (!list.some(p => p.version === parsed.pkg.version)) {
+            list.push(parsed.pkg);
+          }
+        } else {
+          this._pkgsByKey.set(key, [parsed.pkg]);
+        }
+      }
+    }
+    return changed;
+  }
+
+  // Set constraint and maintain the index incrementally
+  private setConstraint(
+    name: string,
+    target: PackageTarget,
+    pkgScope: `${string}/` | null = null
+  ): void {
+    if (pkgScope === null) {
+      this.constraints.primary[name] = target;
+    } else {
+      (this.constraints.secondary[pkgScope] =
+        this.constraints.secondary[pkgScope] || Object.create(null))[name] = target;
+    }
+
+    // Maintain the index incrementally
+    if (this._constraintsByKey) {
+      const key = `${target.registry}:${target.name}`;
+      const constraint: PackageConstraint = {
+        alias: name,
+        pkgScope,
+        ranges: target.ranges
+      };
+      const list = this._constraintsByKey.get(key);
+      if (list) {
+        list.push(constraint);
+      } else {
+        this._constraintsByKey.set(key, [constraint]);
+      }
+    }
+  }
+
+  // Get constraints for a package, building index lazily
+  private getConstraintFor(name: string, registry: string): PackageConstraint[] {
+    if (!this._constraintsByKey) {
+      // Build the index
+      const index = new Map<string, PackageConstraint[]>();
+      for (const [alias, target] of Object.entries(this.constraints.primary)) {
+        if (target instanceof URL) continue;
+        const key = `${target.registry}:${target.name}`;
+        const constraint: PackageConstraint = { alias, pkgScope: null, ranges: target.ranges };
+        const list = index.get(key);
+        if (list) list.push(constraint);
+        else index.set(key, [constraint]);
+      }
+      for (const [pkgScope, scope] of Object.entries(this.constraints.secondary)) {
+        for (const [alias, target] of Object.entries(scope)) {
+          if (target instanceof URL) continue;
+          const key = `${target.registry}:${target.name}`;
+          const constraint: PackageConstraint = {
+            alias,
+            pkgScope: pkgScope as `${string}/`,
+            ranges: target.ranges
+          };
+          const list = index.get(key);
+          if (list) list.push(constraint);
+          else index.set(key, [constraint]);
+        }
+      }
+      this._constraintsByKey = index;
+    }
+
+    return this._constraintsByKey.get(`${registry}:${name}`) || [];
+  }
+
+  // Build the package index lazily
+  private buildPkgIndex(): Map<string, ExactPackage[]> {
+    if (this._pkgsByKey) return this._pkgsByKey;
+
+    const index = new Map<string, ExactPackage[]>();
     for (const pkgUrl of this.pkgUrls) {
-      const pkg = await this.resolver.pm.parseUrlPkg(pkgUrl);
-      if (pkg && (await this.inRange(pkg.pkg, matchPkg))) {
-        if (bestMatch)
+      const parsed = this.resolver.pm.parseUrlPkg(pkgUrl);
+      if (parsed) {
+        const key = `${parsed.pkg.registry}:${parsed.pkg.name}`;
+        const list = index.get(key);
+        if (list) {
+          if (!list.some(p => p.version === parsed.pkg.version)) {
+            list.push(parsed.pkg);
+          }
+        } else {
+          index.set(key, [parsed.pkg]);
+        }
+      }
+    }
+    this._pkgsByKey = index;
+    return index;
+  }
+
+  private async getBestExistingMatch(matchPkg: PackageTarget): Promise<ExactPackage | null> {
+    const index = this.buildPkgIndex();
+    const key = `${matchPkg.registry}:${matchPkg.name}`;
+    const candidates = index.get(key);
+
+    if (!candidates) return null;
+
+    let bestMatch: ExactPackage | null = null;
+    for (const pkg of candidates) {
+      if (matchPkg.ranges.some(range => range.has(pkg.version, true))) {
+        if (bestMatch) {
           bestMatch =
-            Semver.compare(new Semver(bestMatch.version), pkg.pkg.version) === -1
-              ? pkg.pkg
-              : bestMatch;
-        else bestMatch = pkg.pkg;
+            Semver.compare(new Semver(bestMatch.version), pkg.version) === -1 ? pkg : bestMatch;
+        } else {
+          bestMatch = pkg;
+        }
       }
     }
     return bestMatch;
@@ -526,7 +666,7 @@ export class Installer {
     for (const { alias, pkgScope } of installed) {
       const resolution = getResolution(this.installs, alias, pkgScope);
       if (!resolution) continue;
-      this.newInstalls = setResolution(this.installs, alias, pkgUrl, pkgScope);
+      this.newInstalls = this.setResolution(alias, pkgUrl, pkgScope);
     }
 
     return true;
@@ -543,7 +683,7 @@ export class Installer {
       const resolution = getResolution(this.installs, alias, pkgScope);
       if (!resolution) continue;
       if (!ranges.some(range => range.has(pkgVersion, true))) continue;
-      this.newInstalls = setResolution(this.installs, alias, pkgUrl, pkgScope);
+      this.newInstalls = this.setResolution(alias, pkgUrl, pkgScope);
     }
   }
 }

--- a/generator/src/trace/resolver.ts
+++ b/generator/src/trace/resolver.ts
@@ -592,12 +592,6 @@ export class Resolver {
     }
 
     if (pcfg.exports !== undefined && pcfg.exports !== null) {
-      function allDotKeys(exports: Record<string, any>) {
-        for (let p in exports) {
-          if (p[0] !== '.') return false;
-        }
-        return true;
-      }
       if (typeof pcfg.exports === 'string') {
         if (subpath === '.')
           return this.finalizeResolve(

--- a/generator/test/perf/perf.test.js
+++ b/generator/test/perf/perf.test.js
@@ -8,6 +8,7 @@ const largeInstallSet = await (
 
 // First, prime the fetch cache so we are not testing the network as much as possible
 {
+  // await clearCache();
   const generator = new Generator({
     defaultProvider: 'jspm.io',
     resolutions: {

--- a/generator/test/perf/perf.test.js
+++ b/generator/test/perf/perf.test.js
@@ -8,7 +8,6 @@ const largeInstallSet = await (
 
 // First, prime the fetch cache so we are not testing the network as much as possible
 {
-  await clearCache();
   const generator = new Generator({
     defaultProvider: 'jspm.io',
     resolutions: {

--- a/generator/test/perf/perf.test.js
+++ b/generator/test/perf/perf.test.js
@@ -1,4 +1,4 @@
-import { Generator } from '@jspm/generator';
+import { clearCache, Generator } from '@jspm/generator';
 import assert from 'assert';
 import { fetch } from '../../lib/common/fetch.js';
 
@@ -8,6 +8,7 @@ const largeInstallSet = await (
 
 // First, prime the fetch cache so we are not testing the network as much as possible
 {
+  await clearCache();
   const generator = new Generator({
     defaultProvider: 'jspm.io',
     resolutions: {
@@ -18,7 +19,9 @@ const largeInstallSet = await (
   const installs = Object.entries(largeInstallSet).map(([name, versionRange]) => ({
     target: name + '@' + versionRange
   }));
+  const start = performance.now();
   await generator.install(installs);
+  console.log(`PERF TEST TIME (uncached): ${performance.now() - start}ms`);
 }
 
 // Then we do the actual perf test run
@@ -38,5 +41,5 @@ const largeInstallSet = await (
   const start = performance.now();
   await generator.install(installs);
 
-  console.log(`PERF TEST TIME: ${performance.now() - start}ms`);
+  console.log(`PERF TEST TIME (cached): ${performance.now() - start}ms`);
 }

--- a/generator/test/resolve/unused-cjs.test.js
+++ b/generator/test/resolve/unused-cjs.test.js
@@ -26,7 +26,7 @@ assert.deepStrictEqual(generator.getMap(), {
   },
   scopes: {
     './cjspkg/': {
-      jquery: 'https://ga.jspm.io/npm:jquery@3.7.1/dist/jquery.js'
+      jquery: 'https://ga.jspm.io/npm:jquery@4.0.0/dist-module/jquery.module.js'
     }
   }
 });


### PR DESCRIPTION
This optimizes the JSPM Generator internal tracing with caching of hot-paths.

On a performance sensitive generation case, this shows over 75% improvement - 37 seconds down to 9 seconds.