### PR TITLE
feat: traceCache feature for cached generation

### DIFF
--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -2154,12 +2154,10 @@ export {
 };
 
 export type {
-  CachedAnalysis,
   PublishOutput as DeployOutput,
   ExactModule,
   ExactPackage,
   ExportsTarget,
-  GeneratorCache,
   HtmlAnalysis,
   HtmlTag,
   HtmlAttr,

--- a/generator/src/trace/resolver.ts
+++ b/generator/src/trace/resolver.ts
@@ -82,6 +82,9 @@ export class Resolver {
   traceTs: boolean;
   traceSystem: boolean;
   installer: Installer;
+  // Track visited URLs during final extraction for cache pruning
+  // Populated by extractMap's visitor, cleared on each extractMap call
+  visitedUrls: Set<string> = new Set();
   constructor({
     env,
     fetchOpts,

--- a/generator/src/trace/tracemap.ts
+++ b/generator/src/trace/tracemap.ts
@@ -265,6 +265,9 @@ export default class TraceMap {
       map.extend(this.inputMap);
     }
 
+    // Clear visited URLs for cache pruning - will be populated during this extraction
+    this.resolver.visitedUrls.clear();
+
     // visit to build the mappings
     const staticList = new Set();
     const dynamicList = new Set();
@@ -278,6 +281,12 @@ export default class TraceMap {
       entry
     ) => {
       if (!list.has(resolved)) list.add(resolved);
+
+      // Track visited URLs for cache pruning
+      this.resolver.visitedUrls.add(resolved);
+      const pkgUrl = await this.resolver.getPackageBase(resolved);
+      if (pkgUrl) this.resolver.visitedUrls.add(pkgUrl);
+
       // no entry applies to builtins
       if (entry) {
         if (integrity) map.setIntegrity(resolved, entry.integrity);

--- a/generator/test/perf/perf.test.js
+++ b/generator/test/perf/perf.test.js
@@ -6,40 +6,47 @@ const largeInstallSet = await (
   await fetch(new URL('./large-install-set.json', import.meta.url), {})
 ).json();
 
+const installs = Object.entries(largeInstallSet).map(([name, versionRange]) => ({
+  target: name + '@' + versionRange
+}));
+
+const generatorOpts = {
+  defaultProvider: 'jspm.io',
+  resolutions: {
+    react: '16.14.0',
+    porto: '0.0.93'
+  }
+};
+
 // First, prime the fetch cache so we are not testing the network as much as possible
 {
   // await clearCache();
-  const generator = new Generator({
-    defaultProvider: 'jspm.io',
-    resolutions: {
-      react: '16.14.0',
-      porto: '0.0.93'
-    }
-  });
-  const installs = Object.entries(largeInstallSet).map(([name, versionRange]) => ({
-    target: name + '@' + versionRange
-  }));
+  const generator = new Generator(generatorOpts);
   const start = performance.now();
   await generator.install(installs);
   console.log(`PERF TEST TIME (uncached): ${performance.now() - start}ms`);
 }
 
-// Then we do the actual perf test run
+// Then we do the actual perf test run with fetch cache
+let traceCache;
 {
-  const generator = new Generator({
-    defaultProvider: 'jspm.io',
-    resolutions: {
-      react: '16.14.0',
-      porto: '0.0.93'
-    }
-  });
-
-  const installs = Object.entries(largeInstallSet).map(([name, versionRange]) => ({
-    target: name + '@' + versionRange
-  }));
-
+  const generator = new Generator({ ...generatorOpts, traceCache: true });
   const start = performance.now();
   await generator.install(installs);
+  console.log(`PERF TEST TIME (fetch cached): ${performance.now() - start}ms`);
+  traceCache = generator.getCache();
+  console.log(
+    `Trace cache: ${Object.keys(traceCache.packageConfigs).length} packages, ${
+      Object.keys(traceCache.analysis).length
+    } modules`
+  );
+}
 
-  console.log(`PERF TEST TIME (cached): ${performance.now() - start}ms`);
+// Finally, run with trace cache to test generator cache performance
+{
+  // await clearCache();
+  const generator = new Generator({ ...generatorOpts, traceCache });
+  const start = performance.now();
+  await generator.install(installs);
+  console.log(`PERF TEST TIME (trace cached): ${performance.now() - start}ms`);
 }


### PR DESCRIPTION
This adds a new `traceCache` option to the Generator, which allows pre-caching analysis and package.json constraint data. After a generation operation, this data can be obtained from `generator.getCache()`, serialized and stored, then passed to a new generator instance. The network overhead of generation can be entirely avoided this way.

Keys are all URLs, so these objects can be merged straightforwardly between generation operations.