### PR TITLE
fix: support npm package aliases in nodemodules provider

### DIFF
--- a/generator/src/providers/nodemodules.ts
+++ b/generator/src/providers/nodemodules.ts
@@ -99,7 +99,7 @@ export function createProvider(baseUrl: string, ownsBaseUrl: boolean): Provider 
     async function remap(this: ProviderContext, deps: Record<string, string> | null) {
       if (!deps) return;
       for (const [name, dep] of Object.entries(deps)) {
-        if (!isLocal(dep)) continue;
+        if (!isLocal(dep) && !isAlias(dep)) continue;
 
         const remappedUrl = new URL(`./node_modules/${name}`, pkgUrl);
         if (!(await dirExists.call(this, remappedUrl))) continue;
@@ -213,4 +213,8 @@ async function dirExists(this: ProviderContext, url: URL, parentUrl?: string) {
 
 function isLocal(dep: string): boolean {
   return dep.startsWith('file:');
+}
+
+function isAlias(dep: string): boolean {
+  return dep.startsWith('npm:');
 }

--- a/generator/test/providers/npmalias.test.js
+++ b/generator/test/providers/npmalias.test.js
@@ -1,0 +1,17 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+// Test that NPM package aliases (e.g. "jquery3": "npm:jquery@^3.7.1")
+// resolve correctly with the nodemodules provider.
+// See https://github.com/jspm/jspm/issues/2687
+
+const generator = new Generator({
+  mapUrl: new URL('./npmalias/', import.meta.url),
+  defaultProvider: 'nodemodules'
+});
+
+await generator.link('./index.js');
+const json = generator.getMap();
+
+assert.strictEqual(json.imports['jquery3'], './node_modules/jquery3/dist/jquery.js');
+assert.strictEqual(json.imports['jquery4'], './node_modules/jquery4/dist/jquery.js');

--- a/generator/test/providers/npmalias/index.js
+++ b/generator/test/providers/npmalias/index.js
@@ -1,0 +1,2 @@
+import "jquery3";
+import "jquery4";

--- a/generator/test/providers/npmalias/node_modules/jquery3/dist/jquery.js
+++ b/generator/test/providers/npmalias/node_modules/jquery3/dist/jquery.js
@@ -1,0 +1,1 @@
+export default 'jquery3';

--- a/generator/test/providers/npmalias/node_modules/jquery3/package.json
+++ b/generator/test/providers/npmalias/node_modules/jquery3/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "jquery",
+  "version": "3.7.1",
+  "main": "dist/jquery.js"
+}

--- a/generator/test/providers/npmalias/node_modules/jquery4/dist/jquery.js
+++ b/generator/test/providers/npmalias/node_modules/jquery4/dist/jquery.js
@@ -1,0 +1,1 @@
+export default 'jquery4';

--- a/generator/test/providers/npmalias/node_modules/jquery4/package.json
+++ b/generator/test/providers/npmalias/node_modules/jquery4/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "jquery",
+  "version": "4.0.0",
+  "main": "dist/jquery.js"
+}

--- a/generator/test/providers/npmalias/package.json
+++ b/generator/test/providers/npmalias/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "npmalias-test",
+  "exports": {
+    ".": "./index.js"
+  },
+  "dependencies": {
+    "jquery3": "npm:jquery@^3.7.1",
+    "jquery4": "npm:jquery@^4.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes the nodemodules provider's `getPackageConfig` to handle `npm:` aliased dependencies (e.g. `"jquery3": "npm:jquery@^3.7.1"`)
- The `remap` function previously only handled `file:` dependencies, skipping `npm:` aliases. This caused the installer to look for `node_modules/jquery` instead of `node_modules/jquery3`, failing resolution.
- Adds an `isAlias` check so `npm:` prefixed deps are remapped to their `node_modules/<alias>/` directory, matching the existing `file:` dep behavior

Fixes #2687

## Test plan
- [x] New integration test `generator/test/providers/npmalias.test.js` — installs two aliased jQuery versions via nodemodules provider and asserts both resolve to their correct alias directories
- [ ] Full test suite: `chomp test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)