### PR TITLE
fix: handle github: deps in nodemodules provider to prevent infinite loop

### DIFF
--- a/generator/src/providers/nodemodules.ts
+++ b/generator/src/providers/nodemodules.ts
@@ -216,5 +216,5 @@ function isLocal(dep: string): boolean {
 }
 
 function isAlias(dep: string): boolean {
-  return dep.startsWith('npm:');
+  return dep.indexOf(':') > 1;
 }

--- a/generator/test/providers/githubalias.test.js
+++ b/generator/test/providers/githubalias.test.js
@@ -1,0 +1,16 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+// Test that GitHub-prefixed dependencies (e.g. "github:user/foo") resolve
+// correctly with the nodemodules provider instead of freezing.
+// See https://github.com/jspm/jspm/issues/2688
+
+const generator = new Generator({
+  mapUrl: new URL('./githubalias/', import.meta.url),
+  defaultProvider: 'nodemodules'
+});
+
+await generator.link('./index.js');
+const json = generator.getMap();
+
+assert.strictEqual(json.imports['foo'], './node_modules/foo/index.js');

--- a/generator/test/providers/githubalias/index.js
+++ b/generator/test/providers/githubalias/index.js
@@ -1,0 +1,1 @@
+import "foo";

--- a/generator/test/providers/githubalias/node_modules/foo/index.js
+++ b/generator/test/providers/githubalias/node_modules/foo/index.js
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/generator/test/providers/githubalias/node_modules/foo/package.json
+++ b/generator/test/providers/githubalias/node_modules/foo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/generator/test/providers/githubalias/package.json
+++ b/generator/test/providers/githubalias/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "githubalias-test",
+  "exports": {
+    ".": "./index.js"
+  },
+  "dependencies": {
+    "foo": "github:user/foo"
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes infinite loop when a `github:`-prefixed dependency (e.g. `"foo": "github:user/foo"`) is used with the nodemodules provider
- Root cause: `nodeResolve` received `"user/foo"` as the package name, and the `../../` walk-up produced the same URL repeatedly since the name has two path segments but only two levels were traversed
- Generalizes the `isAlias` check from #2694 to match any registry-prefixed dep (colon beyond position 1), covering `npm:`, `github:`, `git+https:`, etc.

Fixes #2688

## Test plan
- [x] New integration test `generator/test/providers/githubalias.test.js` — resolves a `github:user/foo` dep via nodemodules provider
- [x] Existing nodemodules, npmalias, localdeps, and resolve tests still pass
- [ ] Full test suite: `chomp test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)