### PR TITLE
Add experimental warning to jspm publish

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -639,6 +639,11 @@ Download the application package foo@bar into the folder foo, merging its import
 
 Manages publishes to the JSPM providers, currently in experimental preview.
 
+WARNING: jspm publish is experimental and should only be used for prototyping.
+Unlike the https://ga.jspm.io/ CDN which is stable, reliability guarantees are
+not provided for publishing on https://jspm.io/. For reliable package delivery,
+use npm publish — all npm packages are available on the https://ga.jspm.io/ CDN.
+
 For publishing (default):
 
   jspm publish

--- a/cli/src/publish.ts
+++ b/cli/src/publish.ts
@@ -78,6 +78,10 @@ async function readJsonFile(filePath: string, defaultValue: any = {}) {
 export async function eject(flags: EjectFlags) {
   const log = withType('publish/eject');
 
+  console.warn(
+    `${c.yellow('Warning:')} jspm publish is experimental and should only be used for prototyping. Unlike the https://ga.jspm.io/ CDN which is stable, reliability guarantees are not provided for publishing on https://jspm.io/. For reliable package delivery, use npm publish — all npm packages are available on the https://ga.jspm.io/ CDN.`
+  );
+
   const pkg = flags.eject;
 
   if (!pkg.startsWith('app:')) {
@@ -117,6 +121,10 @@ export async function eject(flags: EjectFlags) {
 
 export async function publish(flags: PublishFlags = {}) {
   const log = withType('publish/publish');
+
+  console.warn(
+    `${c.yellow('Warning:')} jspm publish is experimental and should only be used for prototyping. Unlike the https://ga.jspm.io/ CDN which is stable, reliability guarantees are not provided for publishing on https://jspm.io/. For reliable package delivery, use npm publish — all npm packages are available on the https://ga.jspm.io/ CDN.`
+  );
 
   // Use initProject to get validated project configuration
   const { initProject } = await import('./init.ts');


### PR DESCRIPTION
## Summary
- Adds a runtime warning (yellow `Warning:` prefix) when running `jspm publish` or `jspm publish --eject`, noting that the workflow is experimental and should only be used for prototyping
- Adds the same warning text to the `jspm publish --help` usage output
- Directs users to `npm publish` for reliable package delivery, since all npm packages are already available on the stable https://ga.jspm.io/ CDN

## Test plan
- [ ] Run `jspm publish --help` and verify the experimental warning appears in the usage text
- [ ] Run `jspm publish` and verify the yellow warning is printed before any other output
- [ ] Run `jspm publish --eject` and verify the warning is printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)