### PR TITLE
feat: support --hash-entries build flag

### DIFF
--- a/cli/docs.md
+++ b/cli/docs.md
@@ -290,6 +290,7 @@ to generate an optimized production map.
 * `--no-minify`                      Disable build minification (default: true)
 * `-o, --out` _&lt;dir&gt;_                  Path to the output directory for the build (default: dist)
 * `--install`                        Generate import map after build completes (default: true)
+* `--hash-entries`                   Hash entry point filenames in the output 
 * `--integrity`                      Add module integrity attributes to the import map 
 * `--preload` _[mode]_                 Add module preloads to HTML output (default: static, dynamic) 
 * `--root` _&lt;url&gt;_                     URL to treat as server root, i.e. rebase import maps against 
@@ -346,6 +347,11 @@ Build using a custom import map file.
 jspm publish [options]
 ```
 Manages publishes to the JSPM providers, currently in experimental preview.
+
+WARNING: jspm publish is experimental and should only be used for prototyping.
+Unlike the https://ga.jspm.io/ CDN which is stable, reliability guarantees are
+not provided for publishing on https://jspm.io/. For reliable package delivery,
+use npm publish ΓÇö all npm packages are available on the https://ga.jspm.io/ CDN.
 
 For publishing (default):
 

--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -96,7 +96,15 @@ export default async function build(flags: BuildFlags) {
     const { output } = await bundle.generate({
       format: 'esm',
       assetFileNames: '[name][extname]',
-      entryFileNames: '[name]',
+      entryFileNames: flags.hashEntries
+        ? (chunkInfo) => {
+            const name = chunkInfo.name;
+            const dotIdx = name.lastIndexOf('.');
+            if (dotIdx !== -1)
+              return `${name.slice(0, dotIdx)}-[hash:8]${name.slice(dotIdx)}`;
+            return '[name]-[hash:8]';
+          }
+        : '[name]',
       chunkFileNames: 'lib/[name]-[hash:8].js',
       sourcemap: true,
       compact: flags.minify
@@ -143,11 +151,18 @@ export default async function build(flags: BuildFlags) {
         readFileSync(join(projectConfig.projectPath, 'package.json'), 'utf8')
       );
       // TODO: do this properly!
-      pjson.exports = JSON.parse(
-        JSON.stringify(pjson.exports)
-          .replace(/\.ts"/g, '.js"')
-          .replace(/\.mts"/g, '.mjs"')
-      );
+      let exportsStr = JSON.stringify(pjson.exports)
+        .replace(/\.ts"/g, '.js"')
+        .replace(/\.mts"/g, '.mjs"');
+      // Replace entry filenames with their hashed versions
+      if (flags.hashEntries) {
+        for (const chunk of output) {
+          if (chunk.type === 'chunk' && chunk.isEntry && chunk.fileName !== chunk.name) {
+            exportsStr = exportsStr.split(chunk.name).join(chunk.fileName);
+          }
+        }
+      }
+      pjson.exports = JSON.parse(exportsStr);
       const outPath = join(flags.out!, 'package.json');
       const outDir = dirname(outPath);
       await mkdir(outDir, { recursive: true });

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -498,7 +498,8 @@ generateOpts(
       })
       .option('--install', 'Generate import map after build completes', {
         default: true
-      }),
+      })
+      .option('--hash-entries', 'Hash entry point filenames in the output'),
     true
   )
 )
@@ -568,6 +569,8 @@ export interface BuildFlags extends GenerateFlags {
   minify?: boolean;
   /** Generate import map after build completes (defaults to true) */
   install?: boolean;
+  /** Hash entry point filenames in the output */
+  hashEntries?: boolean;
 }
 
 // Publish command - main command is now just publish with --eject flag for eject functionality

--- a/cli/test/build.test.ts
+++ b/cli/test/build.test.ts
@@ -89,6 +89,43 @@ test('build with rollup config', async () => {
   });
 });
 
+test('build with --hash-entries flag', async () => {
+  const filesBuild = await mapDirectory('fixtures/scenario_build_app');
+  await run({
+    files: filesBuild,
+    commands: ['jspm build --out dist --hash-entries --no-install'],
+    validationFn: async (files: Map<string, string>) => {
+      // Entry points should NOT exist with their original names
+      ok(!files.has('dist/app.js'), 'Original app.js should not exist when --hash-entries is used');
+      ok(
+        !files.has('dist/utils.js'),
+        'Original utils.js should not exist when --hash-entries is used'
+      );
+
+      // Find the hashed entry files
+      const hashedApp = [...files.keys()].find(
+        f => f.startsWith('dist/app-') && f.endsWith('.js') && !f.endsWith('.js.map')
+      );
+      const hashedUtils = [...files.keys()].find(
+        f => f.startsWith('dist/utils-') && f.endsWith('.js') && !f.endsWith('.js.map')
+      );
+      ok(hashedApp, 'Hashed app entry file should exist (e.g. dist/app-XXXXXXXX.js)');
+      ok(hashedUtils, 'Hashed utils entry file should exist (e.g. dist/utils-XXXXXXXX.js)');
+
+      // Verify dist package.json exports reference hashed filenames
+      const distPkg = JSON.parse(files.get('dist/package.json')!);
+      ok(
+        distPkg.exports['.'].includes('-') && distPkg.exports['.'].endsWith('.js'),
+        'package.json exports "." should reference hashed filename'
+      );
+      ok(
+        distPkg.exports['./utils'].includes('-') && distPkg.exports['./utils'].endsWith('.js'),
+        'package.json exports "./utils" should reference hashed filename'
+      );
+    }
+  });
+});
+
 test('build with --no-install flag', async () => {
   const filesBuild = await mapDirectory('fixtures/scenario_build_app');
   await run({


### PR DESCRIPTION
Adds one of the features described in https://github.com/jspm/jspm/issues/2699 in supporting hashes in entry point names with a new `--hash-entries` flag.