### PR TITLE
fix: ensure 404s are never cached

### DIFF
--- a/generator/src/common/fetch-node.ts
+++ b/generator/src/common/fetch-node.ts
@@ -27,7 +27,8 @@ export async function clearCache() {
 const _fetch = nodeFetchCache.create({
   cache: new FileSystemCache({
     cacheDirectory: path.join(cacheDir, 'fetch-cache')
-  })
+  }),
+  shouldCacheResponse: response => response.ok
 });
 
 const emptyHeaders = new Headers();


### PR DESCRIPTION
I noticed sometimes 404s seem to get cached and not retry at the actual node fetch cache level.

This might help with that.