### PR TITLE
feat: Convert compatible wildcard exports to prefix mappings losslessly

### DIFF
--- a/generator/src/common/package.ts
+++ b/generator/src/common/package.ts
@@ -54,7 +54,8 @@ export function expandExportsResolutions(
   exports: ExportsTarget | Record<string, ExportsTarget>,
   env: string[],
   files?: Set<string> | undefined,
-  exportsResolutions: Map<string, string> = new Map()
+  exportsResolutions: Map<string, string> = new Map(),
+  trailingSlashSubpaths?: Set<string>
 ) {
   if (typeof exports !== 'object' || exports === null || !allDotKeys(exports)) {
     let targetList = new Set<string>();
@@ -75,7 +76,8 @@ export function expandExportsResolutions(
           subpath,
           target,
           files,
-          exportsResolutions
+          exportsResolutions,
+          trailingSlashSubpaths
         );
       }
     }
@@ -203,7 +205,8 @@ function expandExportsTarget(
   subpath: string,
   target: string,
   files: Set<string> | undefined,
-  entriesMap: Map<string, string>
+  entriesMap: Map<string, string>,
+  trailingSlashSubpaths?: Set<string>
 ) {
   if (!target.startsWith('./') || !(subpath.startsWith('./') || subpath === '.')) return;
   if (target.indexOf('*') === -1 || subpath.indexOf('*') === -1) {
@@ -216,6 +219,22 @@ function expandExportsTarget(
   // First determine the list of files that could match the target glob
   const lhs = target.slice(2, target.indexOf('*'));
   const rhs = target.slice(target.indexOf('*') + 1);
+
+  // Detect wildcard patterns that can be collapsed to trailing-slash mappings.
+  // When subpath and target share the same suffix after '*', all expanded entries
+  // can later be replaced with a single trailing-slash entry in the import map.
+  if (trailingSlashSubpaths) {
+    const subpathSuffix = subpath.slice(subpath.indexOf('*') + 1);
+    if (subpathSuffix === rhs) {
+      const subpathPrefix = subpath.slice(0, subpath.indexOf('*'));
+      // For empty suffixes, trailing-slash is always safe.
+      // For non-empty suffixes, verify all files under the target prefix match
+      // the suffix so the trailing-slash mapping doesn't over-match.
+      if (!subpathSuffix || [...files].filter(f => f.startsWith(lhs)).every(f => f.endsWith(subpathSuffix))) {
+        trailingSlashSubpaths.add(subpathPrefix);
+      }
+    }
+  }
 
   const fileMatches = new Set<string>();
   for (const file of files) {

--- a/generator/src/common/package.ts
+++ b/generator/src/common/package.ts
@@ -47,6 +47,53 @@ export function allDotKeys(exports: Record<string, any>): boolean {
 }
 
 /**
+ * Get the set of export subpath prefixes that can be losslessly collapsed
+ * into trailing-slash import map entries.
+ *
+ * A wildcard export like `"./modules/*": "./modules/*"` can be represented
+ * as `pkg/modules/` → `base/modules/` without expanding individual files.
+ * Suffix wildcards like `"./foo/*.js": "./src/*.js"` are only eligible if
+ * all files under the target prefix match the suffix (no file leakage).
+ */
+export function getWildcardPrefixes(
+  exports: ExportsTarget | Record<string, ExportsTarget>,
+  env: string[],
+  files?: Set<string>
+): Set<string> {
+  const prefixes = new Set<string>();
+  if (typeof exports !== 'object' || exports === null || !allDotKeys(exports)) return prefixes;
+
+  for (const subpath of Object.keys(exports)) {
+    if (subpath.indexOf('*') === -1) continue;
+    let targetList = new Set<string>();
+    expandTargetResolutions(exports[subpath], files, env, targetList, [], true);
+    for (const target of targetList) {
+      if (!target.startsWith('./') || target.indexOf('*') === -1) continue;
+      const targetSuffix = target.slice(target.indexOf('*') + 1);
+      const subpathSuffix = subpath.slice(subpath.indexOf('*') + 1);
+      if (subpathSuffix !== targetSuffix) continue;
+      const subpathPrefix = subpath.slice(0, subpath.indexOf('*'));
+      const targetPrefix = target.slice(2, target.indexOf('*'));
+      // For empty suffixes (trailing wildcard), always safe.
+      // For non-empty suffixes, verify all files under the target prefix match
+      // the suffix so the trailing-slash mapping doesn't over-match.
+      if (files && subpathSuffix) {
+        let safe = true;
+        for (const f of files) {
+          if (f.startsWith(targetPrefix) && !f.endsWith(subpathSuffix)) {
+            safe = false;
+            break;
+          }
+        }
+        if (!safe) continue;
+      }
+      prefixes.add(subpathPrefix);
+    }
+  }
+  return prefixes;
+}
+
+/**
  * Expand a package exports field into its set of subpaths and resolution
  * With an optional file list for expanding globs
  */
@@ -54,8 +101,7 @@ export function expandExportsResolutions(
   exports: ExportsTarget | Record<string, ExportsTarget>,
   env: string[],
   files?: Set<string> | undefined,
-  exportsResolutions: Map<string, string> = new Map(),
-  trailingSlashSubpaths?: Set<string>
+  exportsResolutions: Map<string, string> = new Map()
 ) {
   if (typeof exports !== 'object' || exports === null || !allDotKeys(exports)) {
     let targetList = new Set<string>();
@@ -76,8 +122,7 @@ export function expandExportsResolutions(
           subpath,
           target,
           files,
-          exportsResolutions,
-          trailingSlashSubpaths
+          exportsResolutions
         );
       }
     }
@@ -205,8 +250,7 @@ function expandExportsTarget(
   subpath: string,
   target: string,
   files: Set<string> | undefined,
-  entriesMap: Map<string, string>,
-  trailingSlashSubpaths?: Set<string>
+  entriesMap: Map<string, string>
 ) {
   if (!target.startsWith('./') || !(subpath.startsWith('./') || subpath === '.')) return;
   if (target.indexOf('*') === -1 || subpath.indexOf('*') === -1) {
@@ -219,22 +263,6 @@ function expandExportsTarget(
   // First determine the list of files that could match the target glob
   const lhs = target.slice(2, target.indexOf('*'));
   const rhs = target.slice(target.indexOf('*') + 1);
-
-  // Detect wildcard patterns that can be collapsed to trailing-slash mappings.
-  // When subpath and target share the same suffix after '*', all expanded entries
-  // can later be replaced with a single trailing-slash entry in the import map.
-  if (trailingSlashSubpaths) {
-    const subpathSuffix = subpath.slice(subpath.indexOf('*') + 1);
-    if (subpathSuffix === rhs) {
-      const subpathPrefix = subpath.slice(0, subpath.indexOf('*'));
-      // For empty suffixes, trailing-slash is always safe.
-      // For non-empty suffixes, verify all files under the target prefix match
-      // the suffix so the trailing-slash mapping doesn't over-match.
-      if (!subpathSuffix || [...files].filter(f => f.startsWith(lhs)).every(f => f.endsWith(subpathSuffix))) {
-        trailingSlashSubpaths.add(subpathPrefix);
-      }
-    }
-  }
 
   const fileMatches = new Set<string>();
   for (const file of files) {

--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -515,6 +515,21 @@ export interface GeneratorOptions {
   combineSubpaths?: boolean | 'scopes' | 'both' | 'none';
 
   /**
+   * Whether to expand wildcard exports into individual import map entries.
+   *
+   * @default false
+   *
+   * When false (default), wildcard exports like `"./modules/*": "./modules/*"`
+   * are represented as a single trailing-slash entry (`pkg/modules/` → base/)
+   * instead of being expanded into individual entries per file. This is
+   * lossless and preserves the package's encapsulation boundaries.
+   *
+   * Set to true to expand wildcard exports into individual entries (previous
+   * behavior).
+   */
+  expandWildcards?: boolean;
+
+  /**
    * Enable trace caching to optimize uncached runs.
    *
    * When set to `true`, enables caching of package configs and analysis data
@@ -641,6 +656,8 @@ export class Generator {
   integrity: boolean;
   flattenScopes: boolean;
   combineSubpaths: 'scopes' | 'both' | 'none';
+  expandWildcards: boolean;
+  wildcardPrefixes: Set<string> = new Set();
   scopedLink: boolean;
   cacheEnabled: boolean;
 
@@ -694,6 +711,7 @@ export class Generator {
     customResolver,
     flattenScopes = true,
     combineSubpaths = true,
+    expandWildcards = false,
     scopedLink = false,
     traceCache = undefined
   }: GeneratorOptions = {}) {
@@ -818,6 +836,7 @@ export class Generator {
     this.flattenScopes = flattenScopes;
     this.combineSubpaths =
       combineSubpaths === true ? 'scopes' : combineSubpaths === false ? 'none' : combineSubpaths;
+    this.expandWildcards = expandWildcards;
 
     // Set the fetch retry count
     if (typeof fetchRetries === 'number') setRetryCount(fetchRetries);
@@ -1282,14 +1301,20 @@ export class Generator {
             }
             // If the provider supports it, get a file listing for the package to assist with glob expansions
             const fileList = await this.traceMap.resolver.getFileList(installed.installUrl);
-            // Expand exports into entry point list
+            // Expand exports into entry point list, collecting wildcard prefixes
+            // that can later be collapsed into trailing-slash import map entries
             const resolutionMap = new Map<string, string>();
+            const trailingSlashSubpaths = this.expandWildcards ? undefined : new Set<string>();
             await expandExportsResolutions(
               pcfg.exports,
               this.traceMap.resolver.env,
               fileList,
-              resolutionMap
+              resolutionMap,
+              trailingSlashSubpaths
             );
+            if (trailingSlashSubpaths)
+              for (const prefix of trailingSlashSubpaths)
+                this.wildcardPrefixes.add(alias + prefix.slice(1));
             return [...resolutionMap].map(([subpath, _entry]) => alias + subpath.slice(1));
           } else if (subpaths) {
             subpaths.every(subpath => {
@@ -1624,7 +1649,7 @@ export class Generator {
     if (map) {
       if (this.flattenScopes) map.flatten();
       map.sort();
-      if (this.combineSubpaths !== 'none') map.combineSubpaths(this.combineSubpaths);
+      this.simplify(map);
     }
 
     // If importMap option is set to true, pass a clone of the generator's map
@@ -1764,6 +1789,7 @@ export class Generator {
       preserveSymlinks: this.traceMap.resolver.preserveSymlinks,
       flattenScopes: this.flattenScopes,
       combineSubpaths: this.combineSubpaths,
+      expandWildcards: this.expandWildcards,
       scopedLink: this.scopedLink
     });
     cloned.traceMap.resolver.pm.providers = {
@@ -1799,7 +1825,7 @@ export class Generator {
     map.rebase(mapUrl, rootUrl);
     if (this.flattenScopes) map.flatten();
     map.sort();
-    if (this.combineSubpaths !== 'none') map.combineSubpaths(this.combineSubpaths);
+    this.simplify(map);
     return { map: map.toJSON(), staticDeps, dynamicDeps };
   }
 
@@ -1888,6 +1914,17 @@ export class Generator {
   }
 
   /**
+   * Simplify the import map by collapsing wildcard-expanded prefixes into
+   * trailing-slash entries, and optionally combining scope subpaths.
+   * Wildcard condensing is always applied when expandWildcards is false (lossless).
+   * combineSubpaths() additionally combines scopes (or both) when enabled.
+   */
+  private simplify(map: ImportMap) {
+    map.condenseImports(this.wildcardPrefixes);
+    if (this.combineSubpaths !== 'none') map.combineSubpaths(this.combineSubpaths);
+  }
+
+  /**
    * Obtain the final generated import map, with flattening and subpaths combined
    * (unless otherwise disabled via the Generator flattenScopes and combineSubpaths options).
    *
@@ -1904,7 +1941,7 @@ export class Generator {
     if (mapUrl) map.rebase(mapUrl, rootUrl);
     if (this.flattenScopes) map.flatten();
     map.sort();
-    if (this.combineSubpaths !== 'none') map.combineSubpaths(this.combineSubpaths);
+    this.simplify(map);
     return map.toJSON();
   }
 }

--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -657,7 +657,6 @@ export class Generator {
   flattenScopes: boolean;
   combineSubpaths: 'scopes' | 'both' | 'none';
   expandWildcards: boolean;
-  wildcardPrefixes: Set<string> = new Set();
   scopedLink: boolean;
   cacheEnabled: boolean;
 
@@ -1301,20 +1300,14 @@ export class Generator {
             }
             // If the provider supports it, get a file listing for the package to assist with glob expansions
             const fileList = await this.traceMap.resolver.getFileList(installed.installUrl);
-            // Expand exports into entry point list, collecting wildcard prefixes
-            // that can later be collapsed into trailing-slash import map entries
+            // Expand exports into entry point list
             const resolutionMap = new Map<string, string>();
-            const trailingSlashSubpaths = this.expandWildcards ? undefined : new Set<string>();
             await expandExportsResolutions(
               pcfg.exports,
               this.traceMap.resolver.env,
               fileList,
-              resolutionMap,
-              trailingSlashSubpaths
+              resolutionMap
             );
-            if (trailingSlashSubpaths)
-              for (const prefix of trailingSlashSubpaths)
-                this.wildcardPrefixes.add(alias + prefix.slice(1));
             return [...resolutionMap].map(([subpath, _entry]) => alias + subpath.slice(1));
           } else if (subpaths) {
             subpaths.every(subpath => {
@@ -1920,7 +1913,45 @@ export class Generator {
    * combineSubpaths() additionally combines scopes (or both) when enabled.
    */
   private simplify(map: ImportMap) {
-    map.condenseImports(this.wildcardPrefixes);
+    if (!this.expandWildcards) {
+      const resolver = this.traceMap.resolver;
+      const condensePrefixes: { imports?: Set<string>; scopes?: Record<string, Set<string>> } = {};
+
+      const collectPrefixes = (entries: Record<string, string>, scopeUrl?: string) => {
+        const prefixes = new Set<string>();
+        const seen = new Set<string>();
+        for (const key of Object.keys(entries)) {
+          const resolved = scopeUrl ? map.resolve(key, scopeUrl) : map.resolve(key);
+          const pkgUrl = resolver.getPackageBaseCached(resolved);
+          if (!pkgUrl || seen.has(pkgUrl)) continue;
+          seen.add(pkgUrl);
+          const firstSlash = key.indexOf('/');
+          const pkgName =
+            firstSlash === -1
+              ? key
+              : key[0] === '@'
+              ? key.slice(0, key.indexOf('/', firstSlash + 1))
+              : key.slice(0, firstSlash);
+          for (const prefix of resolver.getWildcardPrefixes(pkgUrl))
+            prefixes.add(pkgName + prefix.slice(1));
+        }
+        return prefixes.size ? prefixes : undefined;
+      };
+
+      const importPrefixes = collectPrefixes(map.imports);
+      if (importPrefixes) condensePrefixes.imports = importPrefixes;
+
+      for (const scopeUrl of Object.keys(map.scopes)) {
+        const scopePrefixes = collectPrefixes(map.scopes[scopeUrl], scopeUrl);
+        if (scopePrefixes) {
+          condensePrefixes.scopes = condensePrefixes.scopes || {};
+          condensePrefixes.scopes[scopeUrl] = scopePrefixes;
+        }
+      }
+
+      if (condensePrefixes.imports || condensePrefixes.scopes)
+        map.condenseImports(condensePrefixes);
+    }
     if (this.combineSubpaths !== 'none') map.combineSubpaths(this.combineSubpaths);
   }
 

--- a/generator/src/trace/resolver.ts
+++ b/generator/src/trace/resolver.ts
@@ -6,7 +6,7 @@ import { importedFrom, isFetchProtocol } from '../common/url.js';
 // @ts-ignore
 import { parse } from 'es-module-lexer/js';
 import type { InstallTarget, PackageTarget } from '../generator.js';
-import { getMapMatch, allDotKeys } from '../common/package.js';
+import { getMapMatch, allDotKeys, getWildcardPrefixes } from '../common/package.js';
 import { builtinSchemes, mappableSchemes, ProviderManager } from '../providers/index.js';
 import {
   Analysis,
@@ -69,6 +69,7 @@ export class Resolver {
   pcfgPromises: Record<string, Promise<PackageConfig | null>> = Object.create(null);
   analysisPromises: Record<string, Promise<void>> = Object.create(null);
   pcfgs: Record<string, PackageConfig | null> = Object.create(null);
+  fileLists: Record<string, Set<string> | undefined> = Object.create(null);
   fetchOpts: any;
   preserveSymlinks;
   pm: ProviderManager;
@@ -209,9 +210,10 @@ export class Resolver {
 
   async getFileList(pkgUrl: string): Promise<Set<string> | undefined> {
     if (!pkgUrl.endsWith('/')) pkgUrl += '/';
+    if (pkgUrl in this.fileLists) return this.fileLists[pkgUrl];
     // First try the provider's own file listing
     const providerFileList = await this.pm.getFileList(pkgUrl);
-    if (providerFileList) return providerFileList;
+    if (providerFileList) return (this.fileLists[pkgUrl] = providerFileList);
     // Walk via the fetch shim's 204 directory convention (file: on Node, or virtual URLs)
     if ((isNode && pkgUrl.startsWith('file:')) || isVirtualUrl(pkgUrl)) {
       const fileList = new Set<string>();
@@ -233,12 +235,12 @@ export class Resolver {
         }
       }
       await walk(pkgUrl, pkgUrl);
-      return fileList;
+      return (this.fileLists[pkgUrl] = fileList);
     }
     // In fetch-only environments, use package.json "files" as the listing
     const pcfg = await this.getPackageConfig(pkgUrl);
     if (pcfg && Array.isArray((pcfg as any).files)) {
-      return new Set(
+      return (this.fileLists[pkgUrl] = new Set(
         (pcfg as any).files.filter(
           (file: string) =>
             typeof file === 'string' &&
@@ -246,8 +248,31 @@ export class Resolver {
             !file.endsWith('/') &&
             !file.startsWith('.')
         )
-      );
+      ));
     }
+  }
+
+  getPackageBaseCached(url: string): `${string}/` | undefined {
+    let testUrl: URL;
+    try {
+      testUrl = new URL('./', url);
+    } catch {
+      return undefined;
+    }
+    const rootUrl = new URL('/', testUrl).href;
+    do {
+      const href = testUrl.href as `${string}/`;
+      if (this.pcfgs[href]) return href;
+      if (testUrl.href === rootUrl) return undefined;
+    } while ((testUrl = new URL('../', testUrl)));
+    return undefined;
+  }
+
+  getWildcardPrefixes(pkgUrl: string): Set<string> {
+    if (!pkgUrl.endsWith('/')) pkgUrl += '/';
+    const pcfg = this.pcfgs[pkgUrl];
+    if (!pcfg?.exports) return new Set();
+    return getWildcardPrefixes(pcfg.exports, this.env, this.fileLists[pkgUrl]);
   }
 
   async getDepList(pkgUrl: string, dev = false): Promise<string[]> {

--- a/generator/test/resolve/wildcard-identity.test.js
+++ b/generator/test/resolve/wildcard-identity.test.js
@@ -1,13 +1,38 @@
 import { Generator } from '@jspm/generator';
 import assert from 'assert';
 
-// Without combineSubpaths for imports, wildcard identity exports
-// expand into individual entries
+// Lossless wildcard condensing is on by default (expandWildcards: false),
+// so identity wildcard exports are always condensed into trailing-slash entries.
 {
   const generator = new Generator({
     mapUrl: import.meta.url,
     defaultProvider: 'nodemodules',
     combineSubpaths: 'scopes'
+  });
+
+  await generator.install({
+    target: new URL('./wildcard-identity', import.meta.url).href,
+    subpaths: true
+  });
+
+  const json = generator.getMap();
+
+  // Main export is still listed
+  assert.strictEqual(json.imports['wildcard-identity'], './wildcard-identity/index.js');
+  // Subpaths are condensed into a trailing-slash entry (lossless)
+  assert.strictEqual(json.imports['wildcard-identity/modules/'], './wildcard-identity/modules/');
+  // Individual entries should not exist
+  assert.strictEqual(json.imports['wildcard-identity/modules/a.js'], undefined);
+  assert.strictEqual(json.imports['wildcard-identity/modules/b.js'], undefined);
+  assert.strictEqual(json.imports['wildcard-identity/modules/c.js'], undefined);
+}
+
+// With expandWildcards: true, wildcard exports are expanded into individual entries
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules',
+    expandWildcards: true
   });
 
   await generator.install({
@@ -31,30 +56,4 @@ import assert from 'assert';
     json.imports['wildcard-identity/modules/c.js'],
     './wildcard-identity/modules/c.js'
   );
-}
-
-// With combineSubpaths: 'both', identity wildcard exports are combined
-// into a single folder mapping
-{
-  const generator = new Generator({
-    mapUrl: import.meta.url,
-    defaultProvider: 'nodemodules',
-    combineSubpaths: 'both'
-  });
-
-  await generator.install({
-    target: new URL('./wildcard-identity', import.meta.url).href,
-    subpaths: true
-  });
-
-  const json = generator.getMap();
-
-  // The main export is still listed
-  assert.strictEqual(json.imports['wildcard-identity'], './wildcard-identity/index.js');
-  // Subpaths are combined into a folder mapping
-  assert.strictEqual(json.imports['wildcard-identity/modules/'], './wildcard-identity/modules/');
-  // Individual entries should not exist
-  assert.strictEqual(json.imports['wildcard-identity/modules/a.js'], undefined);
-  assert.strictEqual(json.imports['wildcard-identity/modules/b.js'], undefined);
-  assert.strictEqual(json.imports['wildcard-identity/modules/c.js'], undefined);
 }

--- a/generator/test/resolve/wildcard-scoped.test.js
+++ b/generator/test/resolve/wildcard-scoped.test.js
@@ -1,0 +1,69 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+// Lossless wildcard condensing works in scopes
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules',
+    combineSubpaths: false
+  });
+
+  await generator.install({
+    target: new URL('./wildcard-scoped/', import.meta.url).href,
+    subpaths: true
+  });
+
+  const json = generator.getMap();
+
+  const scope = json.scopes?.['./wildcard-scoped/'];
+  assert.ok(scope, 'Should have a scope for the fixture');
+  assert.strictEqual(
+    scope['wildcard-dep/modules/'],
+    './wildcard-scoped/node_modules/wildcard-dep/modules/',
+    'Should have trailing-slash entry in scope'
+  );
+  assert.strictEqual(
+    scope['wildcard-dep/modules/a.js'],
+    undefined,
+    'Should not have individual a.js'
+  );
+  assert.strictEqual(
+    scope['wildcard-dep/modules/b.js'],
+    undefined,
+    'Should not have individual b.js'
+  );
+  assert.strictEqual(
+    scope['wildcard-dep/modules/c.js'],
+    undefined,
+    'Should not have individual c.js'
+  );
+}
+
+// With expandWildcards: true, scope entries remain expanded
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules',
+    combineSubpaths: false,
+    expandWildcards: true
+  });
+
+  await generator.install({
+    target: new URL('./wildcard-scoped/', import.meta.url).href,
+    subpaths: true
+  });
+
+  const json = generator.getMap();
+
+  const scope = json.scopes?.['./wildcard-scoped/'];
+  assert.ok(scope, 'Should have a scope for the fixture');
+  assert.strictEqual(
+    scope['wildcard-dep/modules/'],
+    undefined,
+    'Should not have trailing-slash entry'
+  );
+  assert.ok(scope['wildcard-dep/modules/a.js'], 'Should have individual a.js');
+  assert.ok(scope['wildcard-dep/modules/b.js'], 'Should have individual b.js');
+  assert.ok(scope['wildcard-dep/modules/c.js'], 'Should have individual c.js');
+}

--- a/generator/test/resolve/wildcard-scoped/index.js
+++ b/generator/test/resolve/wildcard-scoped/index.js
@@ -1,0 +1,3 @@
+import 'wildcard-dep/modules/a.js';
+import 'wildcard-dep/modules/b.js';
+import 'wildcard-dep/modules/c.js';

--- a/generator/test/resolve/wildcard-scoped/package.json
+++ b/generator/test/resolve/wildcard-scoped/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "wildcard-scoped-test",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./index.js"
+  },
+  "dependencies": {
+    "wildcard-dep": "*"
+  }
+}

--- a/generator/test/resolve/wildcard-subpaths-mixed/index.js
+++ b/generator/test/resolve/wildcard-subpaths-mixed/index.js
@@ -1,0 +1,1 @@
+export default 'main';

--- a/generator/test/resolve/wildcard-subpaths-mixed/package.json
+++ b/generator/test/resolve/wildcard-subpaths-mixed/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "wildcard-mixed-test",
+  "exports": {
+    ".": "./index.js",
+    "./foo/*.js": "./src/*.js"
+  }
+}

--- a/generator/test/resolve/wildcard-subpaths-mixed/src/a.js
+++ b/generator/test/resolve/wildcard-subpaths-mixed/src/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/generator/test/resolve/wildcard-subpaths-mixed/src/b.js
+++ b/generator/test/resolve/wildcard-subpaths-mixed/src/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/generator/test/resolve/wildcard-subpaths-mixed/src/secret.txt
+++ b/generator/test/resolve/wildcard-subpaths-mixed/src/secret.txt
@@ -1,0 +1,1 @@
+sensitive data

--- a/generator/test/resolve/wildcard-subpaths-shadowed/different/special.js
+++ b/generator/test/resolve/wildcard-subpaths-shadowed/different/special.js
@@ -1,0 +1,1 @@
+export default 'special';

--- a/generator/test/resolve/wildcard-subpaths-shadowed/index.js
+++ b/generator/test/resolve/wildcard-subpaths-shadowed/index.js
@@ -1,0 +1,1 @@
+export default 'main';

--- a/generator/test/resolve/wildcard-subpaths-shadowed/modules/a.js
+++ b/generator/test/resolve/wildcard-subpaths-shadowed/modules/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/generator/test/resolve/wildcard-subpaths-shadowed/modules/b.js
+++ b/generator/test/resolve/wildcard-subpaths-shadowed/modules/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/generator/test/resolve/wildcard-subpaths-shadowed/package.json
+++ b/generator/test/resolve/wildcard-subpaths-shadowed/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "wildcard-shadowed-test",
+  "exports": {
+    ".": "./index.js",
+    "./modules/special": "./different/special.js",
+    "./modules/*": "./modules/*"
+  }
+}

--- a/generator/test/resolve/wildcard-subpaths-suffix/index.js
+++ b/generator/test/resolve/wildcard-subpaths-suffix/index.js
@@ -1,0 +1,1 @@
+export default 'main';

--- a/generator/test/resolve/wildcard-subpaths-suffix/package.json
+++ b/generator/test/resolve/wildcard-subpaths-suffix/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "wildcard-suffix-test",
+  "exports": {
+    ".": "./index.js",
+    "./foo/*.js": "./src/*.js"
+  }
+}

--- a/generator/test/resolve/wildcard-subpaths-suffix/src/a.js
+++ b/generator/test/resolve/wildcard-subpaths-suffix/src/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/generator/test/resolve/wildcard-subpaths-suffix/src/b.js
+++ b/generator/test/resolve/wildcard-subpaths-suffix/src/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/generator/test/resolve/wildcard-subpaths.test.js
+++ b/generator/test/resolve/wildcard-subpaths.test.js
@@ -119,10 +119,7 @@ import assert from 'assert';
   const json = generator.getMap();
 
   // Should condense "./foo/*.js" -> "./src/*.js" into a trailing-slash entry
-  assert.ok(
-    json.imports['wildcard-suffix-test/foo/'],
-    'Should have trailing-slash entry for foo/'
-  );
+  assert.ok(json.imports['wildcard-suffix-test/foo/'], 'Should have trailing-slash entry for foo/');
   assert.strictEqual(
     json.imports['wildcard-suffix-test/foo/a.js'],
     undefined,
@@ -158,12 +155,6 @@ import assert from 'assert';
     'Should not have trailing-slash entry when non-matching files exist'
   );
   // Should have individual entries instead
-  assert.ok(
-    json.imports['wildcard-mixed-test/foo/a.js'],
-    'Should have individual entry for a.js'
-  );
-  assert.ok(
-    json.imports['wildcard-mixed-test/foo/b.js'],
-    'Should have individual entry for b.js'
-  );
+  assert.ok(json.imports['wildcard-mixed-test/foo/a.js'], 'Should have individual entry for a.js');
+  assert.ok(json.imports['wildcard-mixed-test/foo/b.js'], 'Should have individual entry for b.js');
 }

--- a/generator/test/resolve/wildcard-subpaths.test.js
+++ b/generator/test/resolve/wildcard-subpaths.test.js
@@ -1,0 +1,169 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+// Test that wildcard exports with subpaths: true produce a single
+// trailing-slash import map entry instead of individual entries per file.
+// This is the fix for https://github.com/jspm/jspm/issues/2702.
+
+// Default combineSubpaths: true
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules'
+  });
+
+  await generator.install({
+    target: new URL('./wildcard-subpaths', import.meta.url).href,
+    subpaths: true
+  });
+
+  const json = generator.getMap();
+
+  // Should have a trailing-slash entry instead of individual entries
+  assert.ok(
+    json.imports['wildcard-subpaths-test/modules/'],
+    'Should have trailing-slash entry for modules/'
+  );
+  assert.strictEqual(
+    json.imports['wildcard-subpaths-test/modules/a.js'],
+    undefined,
+    'Should not have individual entry for a.js'
+  );
+  assert.strictEqual(
+    json.imports['wildcard-subpaths-test/modules/b.js'],
+    undefined,
+    'Should not have individual entry for b.js'
+  );
+  assert.strictEqual(
+    json.imports['wildcard-subpaths-test/modules/c.js'],
+    undefined,
+    'Should not have individual entry for c.js'
+  );
+}
+
+// combineSubpaths: false — should still collapse wildcard-expanded prefixes
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules',
+    combineSubpaths: false
+  });
+
+  await generator.install({
+    target: new URL('./wildcard-subpaths', import.meta.url).href,
+    subpaths: true
+  });
+
+  const json = generator.getMap();
+
+  // Even without combineSubpaths, wildcard prefixes should still be collapsed
+  assert.ok(
+    json.imports['wildcard-subpaths-test/modules/'],
+    'Should have trailing-slash entry even with combineSubpaths: false'
+  );
+  assert.strictEqual(
+    json.imports['wildcard-subpaths-test/modules/a.js'],
+    undefined,
+    'Should not have individual entry for a.js'
+  );
+}
+
+// Shadowed exports: specific exports that override the wildcard should be
+// preserved alongside the trailing-slash entry.
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules',
+    combineSubpaths: false
+  });
+
+  await generator.install({
+    target: new URL('./wildcard-subpaths-shadowed', import.meta.url).href,
+    subpaths: true
+  });
+
+  const json = generator.getMap();
+
+  // Should have the trailing-slash entry for the wildcard
+  assert.ok(
+    json.imports['wildcard-shadowed-test/modules/'],
+    'Should have trailing-slash entry for modules/'
+  );
+  // Should NOT have individual entries for wildcard-matched files
+  assert.strictEqual(
+    json.imports['wildcard-shadowed-test/modules/a.js'],
+    undefined,
+    'Should not have individual entry for a.js'
+  );
+  // The shadowed export should be preserved as a specific entry
+  assert.ok(
+    json.imports['wildcard-shadowed-test/modules/special'],
+    'Should preserve shadowed export for modules/special'
+  );
+}
+
+// Suffix wildcards: "./foo/*.js" -> "./src/*.js" should condense to
+// a trailing-slash entry with remapped base.
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules',
+    combineSubpaths: false
+  });
+
+  await generator.install({
+    target: new URL('./wildcard-subpaths-suffix', import.meta.url).href,
+    subpaths: true
+  });
+
+  const json = generator.getMap();
+
+  // Should condense "./foo/*.js" -> "./src/*.js" into a trailing-slash entry
+  assert.ok(
+    json.imports['wildcard-suffix-test/foo/'],
+    'Should have trailing-slash entry for foo/'
+  );
+  assert.strictEqual(
+    json.imports['wildcard-suffix-test/foo/a.js'],
+    undefined,
+    'Should not have individual entry for a.js'
+  );
+  assert.strictEqual(
+    json.imports['wildcard-suffix-test/foo/b.js'],
+    undefined,
+    'Should not have individual entry for b.js'
+  );
+}
+
+// Mixed file types: "./foo/*.js" -> "./src/*.js" with non-.js files in src/
+// should NOT condense, to avoid leaking non-exported files.
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules',
+    combineSubpaths: false
+  });
+
+  await generator.install({
+    target: new URL('./wildcard-subpaths-mixed', import.meta.url).href,
+    subpaths: true
+  });
+
+  const json = generator.getMap();
+
+  // Should NOT have a trailing-slash entry (would leak secret.txt)
+  assert.strictEqual(
+    json.imports['wildcard-mixed-test/foo/'],
+    undefined,
+    'Should not have trailing-slash entry when non-matching files exist'
+  );
+  // Should have individual entries instead
+  assert.ok(
+    json.imports['wildcard-mixed-test/foo/a.js'],
+    'Should have individual entry for a.js'
+  );
+  assert.ok(
+    json.imports['wildcard-mixed-test/foo/b.js'],
+    'Should have individual entry for b.js'
+  );
+}

--- a/generator/test/resolve/wildcard-subpaths/index.js
+++ b/generator/test/resolve/wildcard-subpaths/index.js
@@ -1,0 +1,1 @@
+export default 'main';

--- a/generator/test/resolve/wildcard-subpaths/modules/a.js
+++ b/generator/test/resolve/wildcard-subpaths/modules/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/generator/test/resolve/wildcard-subpaths/modules/b.js
+++ b/generator/test/resolve/wildcard-subpaths/modules/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/generator/test/resolve/wildcard-subpaths/modules/c.js
+++ b/generator/test/resolve/wildcard-subpaths/modules/c.js
@@ -1,0 +1,1 @@
+export default 'c';

--- a/generator/test/resolve/wildcard-subpaths/package.json
+++ b/generator/test/resolve/wildcard-subpaths/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "wildcard-subpaths-test",
+  "exports": {
+    ".": "./index.js",
+    "./modules/*": "./modules/*"
+  }
+}

--- a/import-map/src/map.ts
+++ b/import-map/src/map.ts
@@ -216,6 +216,40 @@ export class ImportMap implements IImportMap {
    * @param targets Which sections to combine: 'scopes' (default) or 'both' (includes top-level imports)
    * @returns ImportMap for chaining
    */
+  /**
+   * Condense import entries sharing a common prefix into a single
+   * trailing-slash entry. Entries with inconsistent URL bases (e.g.
+   * shadowed exports) are left in place alongside the prefix entry.
+   *
+   * @param prefixes Import key prefixes to condense (e.g. "pkg/modules/")
+   * @returns ImportMap for chaining
+   */
+  condenseImports(prefixes: { imports?: Set<string>, scopes?: Record<string, Set<string>> }) {
+    const condenseMappings = (mappings: Record<string, string>, safePrefixes: Set<string>) => {
+      for (const prefix of safePrefixes) {
+        for (const key of Object.keys(mappings)) {
+          if (!key.startsWith(prefix) || key === prefix) continue;
+          const suffix = key.slice(prefix.length);
+          const value = mappings[key];
+          if (!value.endsWith(suffix)) continue;
+          mappings[prefix] ??= value.slice(0, value.length - suffix.length);
+          if (value.startsWith(mappings[prefix])) {
+            delete mappings[key];
+          }
+        }
+      }
+    };
+
+    if (prefixes.imports)
+      condenseMappings(this.imports, prefixes.imports);
+    if (prefixes.scopes)
+      for (const scope of Object.keys(prefixes.scopes))
+        if (this.scopes[scope])
+          condenseMappings(this.scopes[scope], prefixes.scopes[scope]);
+
+    return this;
+  }
+
   combineSubpaths(targets: 'scopes' | 'both' = 'scopes') {
     // iterate possible bases and submappings, grouping bases greedily
     const combineSubpathMappings = (mappings: Record<string, string>) => {
@@ -314,34 +348,6 @@ export class ImportMap implements IImportMap {
     if (targets === 'scopes' || targets === 'both') {
       for (const scope of Object.keys(this.scopes)) {
         this.scopes[scope] = combineSubpathMappings(this.scopes[scope]);
-      }
-    }
-
-    return this;
-  }
-
-  /**
-   * Condense import entries sharing a common prefix into a single
-   * trailing-slash entry. Entries with inconsistent URL bases (e.g.
-   * shadowed exports) are left in place alongside the prefix entry.
-   *
-   * @param prefixes Import key prefixes to condense (e.g. "pkg/modules/")
-   * @returns ImportMap for chaining
-   */
-  condenseImports(prefixes: Set<string>) {
-    for (const prefix of prefixes) {
-      for (const key in this.imports) {
-        if (!key.startsWith(prefix) || key === prefix) continue;
-
-        const suffix = key.slice(prefix.length);
-        const value = this.imports[key];
-
-        if (!value.endsWith(suffix)) continue;
-
-        this.imports[prefix] ??= value.slice(0, value.length - suffix.length);
-        if (value.startsWith(this.imports[prefix])) {
-          delete this.imports[key];
-        }
       }
     }
 

--- a/import-map/src/map.ts
+++ b/import-map/src/map.ts
@@ -321,6 +321,34 @@ export class ImportMap implements IImportMap {
   }
 
   /**
+   * Condense import entries sharing a common prefix into a single
+   * trailing-slash entry. Entries with inconsistent URL bases (e.g.
+   * shadowed exports) are left in place alongside the prefix entry.
+   *
+   * @param prefixes Import key prefixes to condense (e.g. "pkg/modules/")
+   * @returns ImportMap for chaining
+   */
+  condenseImports(prefixes: Set<string>) {
+    for (const prefix of prefixes) {
+      for (const key in this.imports) {
+        if (!key.startsWith(prefix) || key === prefix) continue;
+
+        const suffix = key.slice(prefix.length);
+        const value = this.imports[key];
+
+        if (!value.endsWith(suffix)) continue;
+
+        this.imports[prefix] ??= value.slice(0, value.length - suffix.length);
+        if (value.startsWith(this.imports[prefix])) {
+          delete this.imports[key];
+        }
+      }
+    }
+
+    return this;
+  }
+
+  /**
    * Groups the import map scopes to shared URLs to reduce duplicate mappings.
    *
    * For two given scopes, "https://site.com/x/" and "https://site.com/y/",
@@ -457,7 +485,7 @@ export class ImportMap implements IImportMap {
     let changedScopeProps = false;
     // Create a temporary map to collect scopes by their rebased URLs
     const rebasedScopes: Record<string, Record<string, string>> = Object.create(null);
-    
+
     for (const scope of Object.keys(this.scopes)) {
       const scopeImports = this.scopes[scope];
       let changedScopeImportProps = false;
@@ -488,7 +516,7 @@ export class ImportMap implements IImportMap {
         mapUrl,
         rootUrl
       );
-      
+
       // Check if this scope URL already exists in our rebased collection
       if (rebasedScopes[newScope]) {
         // Merge the imports from this scope into the existing one
@@ -502,7 +530,7 @@ export class ImportMap implements IImportMap {
         }
       }
     }
-    
+
     // Replace the scopes with the unified rebased scopes
     this.scopes = rebasedScopes;
     if (changedScopeProps) this.scopes = alphabetize(this.scopes);

--- a/import-map/test/cases/combine-subpaths.js
+++ b/import-map/test/cases/combine-subpaths.js
@@ -65,3 +65,137 @@ const map = {
     }
   });
 }
+
+// Prefix condensing: trailing-slash entries from known prefixes
+{
+  const importMap = new ImportMap({
+    map: {
+      imports: {
+        'pkg': './node_modules/pkg/index.js',
+        'pkg/modules/a.js': './node_modules/pkg/modules/a.js',
+        'pkg/modules/b.js': './node_modules/pkg/modules/b.js',
+        'pkg/modules/c.js': './node_modules/pkg/modules/c.js'
+      }
+    }
+  });
+
+  importMap.condenseImports({ imports: new Set(['pkg/modules/']) });
+
+  deepStrictEqual(importMap.toJSON(), {
+    imports: {
+      'pkg': './node_modules/pkg/index.js',
+      'pkg/modules/': './node_modules/pkg/modules/'
+    }
+  });
+}
+
+// Prefix condensing preserves shadowed exports with different targets
+{
+  const importMap = new ImportMap({
+    map: {
+      imports: {
+        'pkg/modules/a.js': './node_modules/pkg/modules/a.js',
+        'pkg/modules/b.js': './node_modules/pkg/modules/b.js',
+        'pkg/modules/special': './node_modules/pkg/different/special.js'
+      }
+    }
+  });
+
+  importMap.condenseImports({ imports: new Set(['pkg/modules/']) });
+
+  deepStrictEqual(importMap.toJSON(), {
+    imports: {
+      'pkg/modules/': './node_modules/pkg/modules/',
+      'pkg/modules/special': './node_modules/pkg/different/special.js'
+    }
+  });
+}
+
+// Prefix condensing is scope-aware: only condenses matching scopes
+{
+  const importMap = new ImportMap({
+    map: {
+      imports: {
+        'pkg/modules/a.js': './node_modules/pkg/modules/a.js',
+        'pkg/modules/b.js': './node_modules/pkg/modules/b.js'
+      },
+      scopes: {
+        '/scope/': {
+          'pkg/modules/a.js': './other/pkg/modules/a.js',
+          'pkg/modules/b.js': './other/pkg/modules/b.js'
+        }
+      }
+    }
+  });
+
+  // Only provide prefixes for imports, not scopes — scopes should remain expanded
+  importMap.condenseImports({ imports: new Set(['pkg/modules/']) });
+
+  deepStrictEqual(importMap.toJSON(), {
+    imports: {
+      'pkg/modules/': './node_modules/pkg/modules/'
+    },
+    scopes: {
+      '/scope/': {
+        'pkg/modules/a.js': './other/pkg/modules/a.js',
+        'pkg/modules/b.js': './other/pkg/modules/b.js'
+      }
+    }
+  });
+}
+
+// Prefix condensing with scope-specific prefixes
+{
+  const importMap = new ImportMap({
+    map: {
+      imports: {
+        'pkg/modules/a.js': './node_modules/pkg/modules/a.js',
+        'pkg/modules/b.js': './node_modules/pkg/modules/b.js'
+      },
+      scopes: {
+        '/scope/': {
+          'pkg/modules/a.js': './other/pkg/modules/a.js',
+          'pkg/modules/b.js': './other/pkg/modules/b.js'
+        }
+      }
+    }
+  });
+
+  // Provide prefixes for both imports and the specific scope
+  importMap.condenseImports({
+    imports: new Set(['pkg/modules/']),
+    scopes: { '/scope/': new Set(['pkg/modules/']) }
+  });
+
+  deepStrictEqual(importMap.toJSON(), {
+    imports: {
+      'pkg/modules/': './node_modules/pkg/modules/'
+    },
+    scopes: {
+      '/scope/': {
+        'pkg/modules/': './other/pkg/modules/'
+      }
+    }
+  });
+}
+
+// No prefixes provided: combineSubpaths behaves as before
+{
+  const importMap = new ImportMap({
+    map: {
+      imports: {
+        'pkg/a.js': './pkg/a.js',
+        'pkg/b.js': './pkg/b.js'
+      }
+    }
+  });
+
+  importMap.sort();
+  importMap.combineSubpaths('both');
+
+  deepStrictEqual(importMap.toJSON(), {
+    imports: {
+      'pkg/': './pkg/'
+    }
+  });
+}


### PR DESCRIPTION
Adds a new `expandWildcards` option: 
- `expandWildcards: false` is the current behavior, 
- `expandWildcards: true` losslessly converts _compatible_ wildcard exports to prefixes as follows: 
	1. Trailing-wildcard exports (e.g. `pkg/*` → `./path/*`) are _always_ converted to prefixes
	2. Wildcard exports with the same prefix (e.g. `pkg/*.js` → `./path/*.js`) are _only_ converted to prefix mappings iff there are no other files in that path
	3. Other wildcard exports are not affected (they are expanded per the previous behavior)

This process is lossless because it preserves the intent of the original export and does not expose any additional files. Therefore, the current default is `false`, as it could be considered a bugfix, but it's easy to change to `true` for compat (or even start off with `true` and convert to `false` in the next major version. Just let me know and I can change it!

For the `underscore` testcase in #2702, this PR would produce:

With `combineSubpaths: false, expandWildcards: false`:

```js
{
        "imports": {
                "underscore": "./node_modules/underscore/modules/index-all.js",
                "underscore/package.json": "./node_modules/underscore/package.json",
                "underscore/underscore": "./node_modules/underscore/underscore",
                "underscore/modules/": "./node_modules/underscore/modules/",
                "underscore/amd/": "./node_modules/underscore/amd/",
                "underscore/cjs/": "./node_modules/underscore/cjs/"
        }
}
```

With `combineSubpaths: "both", expandWildcards: false`:

```json
{
        "imports": {
                "underscore": "./node_modules/underscore/modules/index-all.js",
                "underscore/": "./node_modules/underscore/"
        }
}
```

## Implementation

- `expandExportsTarget()` detects collapsible wildcard patterns via a new `trailingSlashSubpaths` parameter
- New `ImportMap.prototype.condenseImports(prefixes)` replaces matching entries sharing a consistent URL base with a single trailing-slash entry
- `Generator.prototype.simplify()` encapsulates both simplifications and applies wildcard condensing before `combineSubpaths()`. I can get rid of this if you'd prefer and just change the three call sites.

### What about sharing code between `condenseImports()` and `combineSubpaths()`?

I wondered about sharing part of the implementation between the two since they seem to be doing similar things (`combineSubpaths` greedily, `condenseImports` for predefined prefixes) but it seems the two methods solve fundamentally different problems and thus there's not really a meaningful shared abstraction — extracting one would just move code around without reducing complexity.                                                                                            
  - `combineSubpaths()` does greedy discovery — it scans all entries and tries to find common prefixes by progressively shortening paths. It doesn't know which prefixes are valid; it just merges whatever it can. That's why it's lossy.                                                                                                                                                                                   
  - `condenseImports(prefixes)` does targeted condensing — it receives specific prefixes already identified as wildcard patterns during export expansion. It only touches those.                                  
                                                                                                                                                                                                                
A shared utility would need to go one of two ways:                                                                                                                                                            
1. Accept a set of prefixes → but then `combineSubpaths()` would need to discover prefixes first, which is most of its logic                                                                                      
2. Be greedy → but then `condenseImports()` loses its losslessness guarantee                                                                                                                                      

The discovery logic in `combineSubpaths` (progressively shortening paths to find a common base) is structurally different from the verification logic in `condenseImports` (check entries under a known prefix).

### What about a single setting for both?

That said, it _could_ make sense to expose a unified API and have a single setting (name & values TBD), with the following "levels":
1. Never combine anything, expand all wildcards
2. Only use prefixes for trailing-wildcard exports, expand everything else
3. Only use prefixes for trailing-wildcard exports, and compatible suffixes (the current `expandWildcards: false` that this PR introduces)
4. All of the above, plus post-hoc combining of everything we can combine (the current `combineSubpaths: true`)

## Things tested

- [x] Basic wildcard condensing (`./modules/*` → trailing-slash entry)
- [x] Works with both combineSubpaths: true and false
- [x] Shadowed exports preserved alongside trailing-slash entry
- [x] Suffix wildcards (`*.js` → `*.js`) condense correctly
- [x] Mixed file types: suffix wildcards with non-matching files in target dir are NOT condensed (no file leakage)
- [x] Manual test with underscore (`subpaths: true`)
- [ ] Other providers (so far only tested with `nodemodules`)

🤖 Co-authored with [Claude Code](https://claude.com/claude-code). 
👩🏽‍💻 Reviewed, iterated on, and tested by this human (except for the tests, I only skimmed those)