### PR TITLE
feat: inputMapFallbacks option

### DIFF
--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -553,6 +553,23 @@ export interface GeneratorOptions {
    * ```
    */
   traceCache?: GeneratorCache | true;
+
+  /**
+   * Controls how flattened scopes from the inputMap are used as fallback
+   * resolutions during dependency installation.
+   *
+   * When the inputMap has a flattened scope (e.g. "https://ga.jspm.io/") with
+   * a mapping for a package, child scopes may inherit that mapping via URL
+   * prefix matching even when the version is incompatible with what they need.
+   *
+   * - `true` (default): All flattened scope resolutions are trusted as locks.
+   * - `false`: Flattened scope resolutions from the inputMap are ignored entirely.
+   *   Dependencies are resolved fresh from package.json ranges.
+   * - `'semver-compatible'`: Flattened scope resolutions are only used when they
+   *   satisfy the dependent package's declared semver range. To be made the
+   *   default in the next major.
+   */
+  inputMapFallbacks?: boolean | 'semver-compatible';
 }
 
 /**
@@ -712,7 +729,8 @@ export class Generator {
     combineSubpaths = true,
     expandWildcards = false,
     scopedLink = false,
-    traceCache = undefined
+    traceCache = undefined,
+    inputMapFallbacks = true
   }: GeneratorOptions = {}) {
     this.cacheEnabled = !!traceCache;
     if (typeof preserveSymlinks !== 'boolean') preserveSymlinks = isNode;
@@ -801,7 +819,8 @@ export class Generator {
         resolutions,
         commonJS,
         customResolver,
-        noPins: scopedLink
+        noPins: scopedLink,
+        inputMapFallbacks
       },
       log,
       resolver

--- a/generator/src/install/installer.ts
+++ b/generator/src/install/installer.ts
@@ -85,6 +85,7 @@ export interface InstallerOptions {
   defaultProvider?: string;
   defaultRegistry?: string;
   providers?: Record<string, string>;
+  inputMapFallbacks?: boolean | 'semver-compatible';
 }
 
 export class Installer {
@@ -456,19 +457,24 @@ export class Installer {
     // Pick up resolutions from flattened scopes like 'https://ga.jspm.io/"
     // for secondary installs, if they're in range for the current pjson, or
     // if we're in a freeze install:
-    if (!isTopLevel) {
-      const flattenedResolution = getFlattenedResolution(
+    if (!isTopLevel && this.opts.inputMapFallbacks !== false) {
+      const semverCompatible = this.opts.inputMapFallbacks === 'semver-compatible';
+      const flattenedResolution = await getFlattenedResolution(
         this.installs,
         pkgName,
         pkgScope,
-        traceSubpath
+        traceSubpath,
+        semverCompatible,
+        semverCompatible && pjsonTarget
+          ? async (installUrl: string) => this.inRange(installUrl, pjsonTarget.pkgTarget)
+          : null
       );
 
       if (
         !useLatestPjsonTarget &&
         flattenedResolution &&
-        (mode === 'freeze' ||
-          (await this.inRange(flattenedResolution.installUrl, pjsonTarget.pkgTarget)))
+        (mode === 'freeze' && !semverCompatible ||
+          pjsonTarget && (await this.inRange(flattenedResolution.installUrl, pjsonTarget.pkgTarget)))
       ) {
         this.newInstalls = this.setResolution(pkgName, flattenedResolution.installUrl, pkgScope);
         return flattenedResolution;

--- a/generator/src/install/lock.ts
+++ b/generator/src/install/lock.ts
@@ -80,12 +80,14 @@ export function getResolution(
   return scope?.[name] ?? null;
 }
 
-export function getFlattenedResolution(
+export async function getFlattenedResolution(
   resolutions: LockResolutions,
   name: string,
   pkgScope: `${string}/`,
-  flattenedSubpath: `.${string}`
-): InstalledResolution | null {
+  flattenedSubpath: `.${string}`,
+  semverCompatible = false,
+  inRange: ((installUrl: string) => Promise<boolean>) | null = null
+): Promise<InstalledResolution | null> {
   // no current scope -> check the flattened scopes
   const parentScopes = enumerateParentScopes(pkgScope);
   for (const scopeUrl of parentScopes) {
@@ -97,6 +99,9 @@ export function getFlattenedResolution(
         flatResolution.export === flattenedSubpath ||
         (flatResolution.export.endsWith('/') && flattenedSubpath.startsWith(flatResolution.export))
       ) {
+        if (semverCompatible && inRange && !(await inRange(flatResolution.resolution.installUrl))) {
+          continue;
+        }
         return flatResolution.resolution;
       }
     }

--- a/generator/src/trace/tracemap.ts
+++ b/generator/src/trace/tracemap.ts
@@ -64,6 +64,8 @@ export interface TraceMapOptions extends InstallerOptions {
    * This will be the default in the next major.
    */
   noPins?: boolean;
+
+  inputMapFallbacks?: boolean | 'semver-compatible';
 }
 
 interface VisitOpts {

--- a/generator/test/api/fallbacks.test.js
+++ b/generator/test/api/fallbacks.test.js
@@ -1,0 +1,84 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+// When an inputMap has a flattened scope with entities@4.5.0 (from
+// htmlparser2@8.0.1), and react-html-parser is linked pulling in
+// htmlparser2@3.10.1 which needs entities@^1.1.1, the flattened
+// entities@4.5.0 must not be used for htmlparser2@3.10.1's resolution.
+
+const inputMap = {
+  imports: {
+    'htmlparser2': 'https://ga.jspm.io/npm:htmlparser2@8.0.1/lib/esm/index.js',
+  },
+  scopes: {
+    'https://ga.jspm.io/': {
+      'entities': 'https://ga.jspm.io/npm:entities@4.5.0/lib/esm/index.js',
+      'entities/lib/': 'https://ga.jspm.io/npm:entities@4.5.0/lib/',
+      'entities/lib/decode.js': 'https://ga.jspm.io/npm:entities@4.5.0/lib/esm/decode.js',
+      'entities/lib/escape.js': 'https://ga.jspm.io/npm:entities@4.5.0/lib/esm/escape.js',
+      'domelementtype': 'https://ga.jspm.io/npm:domelementtype@2.3.0/lib/esm/index.js',
+      'domhandler': 'https://ga.jspm.io/npm:domhandler@5.0.3/lib/esm/index.js',
+      'domutils': 'https://ga.jspm.io/npm:domutils@3.1.0/lib/esm/index.js',
+      'dom-serializer': 'https://ga.jspm.io/npm:dom-serializer@2.0.0/lib/esm/index.js',
+    },
+    'https://ga.jspm.io/npm:react-html-parser@2.0.2/': {
+      'htmlparser2': 'https://ga.jspm.io/npm:htmlparser2@3.10.1/lib/index.js',
+    },
+    'https://ga.jspm.io/npm:htmlparser2@3.10.1/': {
+      'domelementtype': 'https://ga.jspm.io/npm:domelementtype@1.3.1/index.js',
+      'domutils': 'https://ga.jspm.io/npm:domutils@1.7.0/index.js',
+      'domhandler': 'https://ga.jspm.io/npm:domhandler@2.4.2/index.js',
+    },
+  }
+};
+
+// inputMapFallbacks: 'semver-compatible' — rejects incompatible flattened locks
+{
+  const generator = new Generator({
+    inputMap,
+    mapUrl: new URL('about:blank'),
+    defaultProvider: 'jspm.io',
+    env: ['production', 'browser'],
+    inputMapFallbacks: 'semver-compatible',
+  });
+
+  await generator.link('react-html-parser');
+
+  const map = generator.getMap();
+  const gaScope = map.scopes?.['https://ga.jspm.io/'];
+
+  assert.ok(gaScope?.['entities/lib/decode_codepoint.js']?.includes(':entities@1.'),
+    'semver-compatible: entities/lib/decode_codepoint.js must resolve to entities@1.x');
+
+  assert.ok(!gaScope?.['entities/lib/']?.includes(':entities@4.'),
+    'semver-compatible: entities/lib/ prefix must not route to entities@4.x');
+}
+
+// inputMapFallbacks: false — ignores all flattened locks
+{
+  const generator = new Generator({
+    inputMap,
+    mapUrl: new URL('about:blank'),
+    defaultProvider: 'jspm.io',
+    env: ['production', 'browser'],
+    inputMapFallbacks: false,
+  });
+
+  await generator.link('react-html-parser');
+
+  const map = generator.getMap();
+  const gaScope = map.scopes?.['https://ga.jspm.io/'];
+
+  assert.ok(gaScope?.['entities/lib/decode_codepoint.js']?.includes(':entities@1.'),
+    'false: entities/lib/decode_codepoint.js must resolve to entities@1.x');
+
+  assert.ok(!gaScope?.['entities/lib/']?.includes(':entities@4.'),
+    'false: entities/lib/ prefix must not route to entities@4.x');
+
+  // With false, the flattened entities@4.5.0 should not appear at all
+  // for packages that didn't independently resolve to it
+  const hp2Scope = map.scopes?.['https://ga.jspm.io/npm:htmlparser2@3.10.1/'];
+  const hp2Entities = hp2Scope?.['entities'] || '';
+  assert.ok(!hp2Entities.includes(':entities@4.'),
+    'false: htmlparser2@3.10.1 must not have entities@4.x');
+}


### PR DESCRIPTION
This adds a new option, `inputMapFallbacks` which can be set to `false` or `'semver-compatible'` to change the way top-level scopes fallbacks (like `https://ga.jspm.io/`) get treated when handling the `inputMap` option.

Setting this to `semver-compatible` allows bad input maps to still generate valid mappings, by verifying any fallbacks used checking if they satisfy the expected semver ranges of the dependencies being matched to those fallbacks.

This is useful for badly merged import maps that would otherwise give incorrect version resolutions with API breaks to be generated.