### PR TITLE
fix(ci): skip auth-dependent tests when JSPM_TOKEN is unavailable

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: main
 
+env:
+  JSPM_TOKEN: ${{ secrets.JSPM_TOKEN }}
+
 jobs:
   test:
     name: Node.js Tests
@@ -32,7 +35,8 @@ jobs:
       - run: npm install
       - run: chomp -c cli lint
       - run: npm run -ws build
-      - run: node cli/dist/jspm.js config set -p jspm.io authToken ${{ secrets.JSPM_TOKEN }}
+      - run: node cli/dist/jspm.js config set -p jspm.io authToken "$JSPM_TOKEN"
+        if: env.JSPM_TOKEN != ''
       - run: chomp -c cli test
   deno-test:
     name: Deno Tests
@@ -54,5 +58,6 @@ jobs:
       - run: npm install
       - run: npm run -ws build
       - run: deno test --no-check --allow-all cli/test/deno_test.ts
-      - run: node cli/dist/jspm.js config set -p jspm.io authToken ${{ secrets.JSPM_TOKEN }}
+      - run: node cli/dist/jspm.js config set -p jspm.io authToken "$JSPM_TOKEN"
+        if: env.JSPM_TOKEN != ''
       - run: chomp -c cli deno:test

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -35,7 +35,7 @@ jobs:
       - run: npm install
       - run: chomp -c cli lint
       - run: npm run -ws build
-      - run: node cli/dist/jspm.js config set -p jspm.io authToken "$JSPM_TOKEN"
+      - run: node cli/dist/jspm.js config set -p jspm.io authToken ${{ secrets.JSPM_TOKEN }}
         if: env.JSPM_TOKEN != ''
       - run: chomp -c cli test
   deno-test:
@@ -58,6 +58,6 @@ jobs:
       - run: npm install
       - run: npm run -ws build
       - run: deno test --no-check --allow-all cli/test/deno_test.ts
-      - run: node cli/dist/jspm.js config set -p jspm.io authToken "$JSPM_TOKEN"
+      - run: node cli/dist/jspm.js config set -p jspm.io authToken ${{ secrets.JSPM_TOKEN }}
         if: env.JSPM_TOKEN != ''
       - run: chomp -c cli deno:test

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: main
 
+env:
+  JSPM_AUTH_TOKEN: ${{ secrets.JSPM_TOKEN }}
+
 jobs:
   test-build:
     name: Build & Type Test
@@ -52,7 +55,6 @@ jobs:
       - run: npm run -ws build
       - run: chomp -c generator test:browser
         env:
-          JSPM_AUTH_TOKEN: ${{ secrets.JSPM_TOKEN }}
           CI_BROWSER: C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe
           CI_BROWSER_FLAGS: -headless
           CI_BROWSER_FLUSH: taskkill /F /IM firefox.exe
@@ -85,4 +87,3 @@ jobs:
     - run: chomp -c generator test
       env:
         SKIP_BROWSER: 1
-        JSPM_AUTH_TOKEN: ${{ secrets.JSPM_TOKEN }}

--- a/generator/test/api/node.importmap-publish.test.js
+++ b/generator/test/api/node.importmap-publish.test.js
@@ -1,6 +1,11 @@
 import { Generator } from '@jspm/generator';
 import assert from 'assert';
 
+if (!process.env.JSPM_AUTH_TOKEN) {
+  console.log('Skipping publish tests — JSPM_AUTH_TOKEN not set');
+  process.exit(0);
+}
+
 // Test publishing a package with importMap enabled
 // First we need to create a generator and install a package
 // Then publish with importMap: true

--- a/generator/test/api/node.publish.test.js
+++ b/generator/test/api/node.publish.test.js
@@ -2,9 +2,8 @@ import { Generator } from '@jspm/generator';
 import assert from 'assert';
 
 if (!process.env.JSPM_AUTH_TOKEN) {
-  throw new Error(`!!! JSPM CI CONFIGURATION ERROR !!!
-
-Publish tests require the test auth token`);
+  console.log('Skipping publish tests — JSPM_AUTH_TOKEN not set');
+  process.exit(0);
 }
 
 function generateRandomName() {}


### PR DESCRIPTION
## Summary
- For fork PRs, GitHub Actions does not expose repository secrets, causing CI failures
- **cli.yml**: `jspm config set -p jspm.io authToken` failed with no value argument — now gated with `if: env.JSPM_TOKEN != ''`
- **generator publish tests**: `node.publish.test.js` threw a hard error, `node.importmap-publish.test.js` failed at runtime — both now skip gracefully with `process.exit(0)` when `JSPM_AUTH_TOKEN` is unset
- Moved `JSPM_TOKEN`/`JSPM_AUTH_TOKEN` to workflow-level env for cleaner access

## Test plan
- [ ] CI passes on this PR (secrets available as repo member)
- [ ] Fork PRs skip publish tests and `config set` steps instead of failing