### PR TITLE
fix(ci): skip cli publish tests when JSPM_TOKEN is unavailable

### DIFF
--- a/cli/test/publish.test.ts
+++ b/cli/test/publish.test.ts
@@ -18,6 +18,11 @@ import { test } from 'node:test';
 import assert from 'assert';
 import { mapDirectory, run } from './scenarios.ts';
 
+if (!process.env.JSPM_TOKEN) {
+  console.log('Skipping publish tests — JSPM_TOKEN not set');
+  process.exit(0);
+}
+
 function randomVersion() {
   const major = Math.round(Math.random() * 1000);
   const minor = Math.round(Math.random() * 1000);


### PR DESCRIPTION
## Summary

- Mirrors the skip guard added in #2724 for generator publish tests, applying it to `cli/test/publish.test.ts`.
- Fork PRs (e.g. #2720) don't have access to the `JSPM_TOKEN` secret, so publish tests currently fail with `No auth token has been generated for jspm.io`.

## Test plan

- [ ] CI passes on this PR (no token → publish tests skipped)
- [ ] Main branch CI continues to run publish tests with the token configured