### PR TITLE
cli: TS source maps via workspace + in-browser syntax errors

### DIFF
--- a/cli/src/serve-utils.ts
+++ b/cli/src/serve-utils.ts
@@ -9,6 +9,80 @@ import {
   getLatestEsms
 } from './utils.ts';
 
+// Best-effort extraction of top-level export names from a TS source that
+// may contain syntax errors. Used only as a fallback when amaro's parser
+// fails — we need to keep importers linkable so the SyntaxError stub from
+// serve.ts reaches the browser console instead of being masked by an earlier
+// "does not provide an export named X" link error.
+//
+// Strategy: blank out comments and string/template literals (preserving
+// newlines so positions stay sensible) so `export` can't match inside them,
+// then walk every `export ...` occurrence and pattern-match the common forms.
+// Type-only exports (interface, type) emit no runtime binding and are skipped.
+export function extractExportNames(source: string): string[] {
+  const blank = (m: string) => m.replace(/[^\n]/g, ' ');
+  const stripped = source
+    .replace(/\/\*[\s\S]*?\*\//g, blank)
+    .replace(/\/\/[^\n]*/g, blank)
+    .replace(/(['"])(?:\\.|(?!\1).)*?\1/g, blank)
+    .replace(/`(?:\\[\s\S]|\$\{[^}]*\}|(?!`)[\s\S])*?`/g, blank);
+
+  const names = new Set<string>();
+  const ID = '[A-Za-z_$][\\w$]*';
+  const re = /\bexport\s+/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(stripped))) {
+    const rest = stripped.slice(m.index + m[0].length);
+
+    if (/^default\b/.test(rest)) {
+      names.add('default');
+      continue;
+    }
+    if (/^(?:type|interface)\b/.test(rest)) continue;
+
+    let sub = rest.match(new RegExp(`^\\*\\s+as\\s+(${ID})`));
+    if (sub) {
+      names.add(sub[1]);
+      continue;
+    }
+    if (/^\*/.test(rest)) continue; // export * from — names not recoverable
+
+    sub = rest.match(new RegExp(`^(?:async\\s+)?function\\s*\\*?\\s*(${ID})`));
+    if (sub) {
+      names.add(sub[1]);
+      continue;
+    }
+    sub = rest.match(new RegExp(`^(?:class|enum|namespace)\\s+(${ID})`));
+    if (sub) {
+      names.add(sub[1]);
+      continue;
+    }
+    sub = rest.match(new RegExp(`^(?:const|let|var)\\s+(${ID})`));
+    if (sub) {
+      names.add(sub[1]);
+      continue;
+    }
+
+    if (rest[0] === '{') {
+      const close = rest.indexOf('}');
+      if (close > 0) {
+        for (const spec of rest.slice(1, close).split(',')) {
+          const t = spec.trim();
+          if (!t) continue;
+          const asMatch = t.match(new RegExp(`\\sas\\s+(${ID})\\s*$`));
+          if (asMatch) {
+            names.add(asMatch[1]);
+          } else {
+            const idMatch = t.match(new RegExp(`^(${ID})`));
+            if (idMatch) names.add(idMatch[1]);
+          }
+        }
+      }
+    }
+  }
+  return [...names];
+}
+
 // Function to display keyboard shortcuts
 let showingShortcuts = false;
 let showingShortcutsWatch = false;

--- a/cli/src/serve.ts
+++ b/cli/src/serve.ts
@@ -27,6 +27,7 @@ import notFoundPage from './views/not-found.ts';
 import createHotMap from './views/hot-map.ts';
 import {
   esmsCodeSnippet,
+  extractExportNames,
   getFileMtimes,
   hideShortcuts,
   lintMessage,
@@ -123,8 +124,8 @@ export default async function serve(flags: ServeFlags = {}) {
 
       // Rlve to the actual file system path
       let filePath = join(resolvedDir, reqPath);
-      const tsOriginal = filePath.endsWith('.ts.original') || filePath.endsWith('.mts.original');
-      if (tsOriginal) filePath = filePath.slice(0, -9);
+      const tsMap = filePath.endsWith('.ts.map') || filePath.endsWith('.mts.map');
+      if (tsMap) filePath = filePath.slice(0, -4);
       const relativePath = relative(resolvedDir, filePath).replace(/\\/g, '/');
 
       // Basic security check to prevent directory traversal
@@ -163,11 +164,26 @@ export default async function serve(flags: ServeFlags = {}) {
           const map = readInputMap(outputMapPath);
           res.writeHead(200, { 'Content-Type': 'text/javascript' });
           res.end(createHotMap(map));
-        } else if (tsOriginal) {
-          // Serve the original TypeScript file without transformation
+        } else if (tsMap) {
+          // Identity source map for type-stripped TS. amaro's strip-only mode
+          // preserves line and column positions, so each generated line maps
+          // 1:1 to the same line in the original source.
           const content = await readFile(filePath, 'utf8');
-          res.writeHead(200, { 'Content-Type': 'application/typescript' });
-          res.end(content);
+          const lines = content.split('\n').length;
+          const sourceName = basename(filePath);
+          const map = {
+            version: 3,
+            file: sourceName,
+            sources: [sourceName],
+            sourcesContent: [content],
+            names: [],
+            mappings: 'AAAA' + ';AACA'.repeat(Math.max(0, lines - 1))
+          };
+          res.writeHead(200, {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*'
+          });
+          res.end(JSON.stringify(map));
         } else if (filePath.endsWith('.jsx') || filePath.endsWith('.tsx')) {
           lintMessage({
             file: relativePath,
@@ -195,8 +211,11 @@ export default async function serve(flags: ServeFlags = {}) {
             const strippedCode = transformSync(tsContent, {
               transform: { mode: 'strip-only', noEmptyExport: true }
             }).code;
-            // Add sourceURL comment to preserve original filename in devtools
-            const jsCode = `${strippedCode}\n//# sourceURL=${basename(filePath)}.original`;
+            // Reference an external identity source map so DevTools (when open)
+            // resolves the original TypeScript by its canonical URL — the URL
+            // that the workspace folder integration binds to the on-disk file,
+            // enabling edit-from-debugger writeback.
+            const jsCode = `${strippedCode}\n//# sourceMappingURL=${basename(filePath)}.map`;
             res.writeHead(200, { 'Content-Type': 'text/javascript' });
             res.end(jsCode);
           } catch (error) {
@@ -210,9 +229,31 @@ ${c.bold(
 )}
 ${error.snippet}`
             );
-            res.writeHead(500);
+            // Emit a JS module that throws a SyntaxError at the same line as
+            // the original parse error so DevTools maps the stack frame back
+            // to the offending TS location via the .ts.map identity map.
+            // Must be 2xx — module scripts only execute on success.
+            // Re-declare export names so importers can still link; otherwise
+            // the link error ("does not provide an export named X") would
+            // mask the actual SyntaxError this stub raises at evaluation.
+            const startLine = error.startLine || 1;
+            const startCol = error.startColumn || 0;
+            // Strip ANSI escapes from snippet so terminal colours don't leak
+            // into the browser console as raw control sequences.
+            const snippet = String(error.snippet || '').replace(/\[[\d;]*m/g, '');
+            const msg = snippet ? `${error.message}\n${snippet}` : error.message;
+            const exportNames = extractExportNames(tsContent);
+            const exportPrefix =
+              exportNames.length > 0
+                ? exportNames
+                    .map(n => (n === 'default' ? 'export default undefined' : `export let ${n}`))
+                    .join(';') + ';\n'
+                : '';
+            const linePad = '\n'.repeat(Math.max(0, startLine - (exportPrefix ? 2 : 1)));
+            const colPad = ' '.repeat(startCol);
+            res.writeHead(200, { 'Content-Type': 'text/javascript' });
             res.end(
-              `throw new Error(\`JSPM Server: Error transforming TypeScript file: ${error.message}\`);`
+              `${exportPrefix}${linePad}${colPad}throw new SyntaxError(${JSON.stringify(msg)});\n//# sourceMappingURL=${basename(filePath)}.map`
             );
             showShortcuts(serverUrl, !flags.static);
           }
@@ -476,7 +517,10 @@ ${error.snippet}`
         console.log('');
       } catch (e) {
         stopSpinner();
-        console.error(`${c.red('Install Error:')} `, e instanceof JspmError ? e.message : e);
+        console.error(
+          `${c.red('Install Error:')} `,
+          e instanceof Error ? e.message : e
+        );
         return null;
       }
       if (!result) return null;

--- a/cli/src/serve.ts
+++ b/cli/src/serve.ts
@@ -177,7 +177,7 @@ export default async function serve(flags: ServeFlags = {}) {
             sources: [sourceName],
             sourcesContent: [content],
             names: [],
-            mappings: 'AAAA' + ';AACA'.repeat(Math.max(0, lines - 1))
+            mappings: `AAAA${';AACA'.repeat(Math.max(0, lines - 1))}`
           };
           res.writeHead(200, {
             'Content-Type': 'application/json',
@@ -245,9 +245,9 @@ ${error.snippet}`
             const exportNames = extractExportNames(tsContent);
             const exportPrefix =
               exportNames.length > 0
-                ? exportNames
+                ? `${exportNames
                     .map(n => (n === 'default' ? 'export default undefined' : `export let ${n}`))
-                    .join(';') + ';\n'
+                    .join(';')};\n`
                 : '';
             const linePad = '\n'.repeat(Math.max(0, startLine - (exportPrefix ? 2 : 1)));
             const colPad = ' '.repeat(startCol);

--- a/cli/test/install.test.ts
+++ b/cli/test/install.test.ts
@@ -49,7 +49,7 @@ test('Local install', async () => {
     validationFn: async (files: Map<string, string>) => {
       const map: IImportMap = JSON.parse(files.get('pkg2/importmap.json')!);
       assert.ok(map.scopes?.['https://cdn.jsdelivr.net/npm/lit-element@4.2.2/']);
-      assert.ok(map.scopes?.['https://cdn.jsdelivr.net/npm/lit@3.3.2/']);
+      assert.ok(map.scopes?.['https://cdn.jsdelivr.net/npm/lit@3.3.3/']);
     }
   });
 });

--- a/cli/test/providers.test.ts
+++ b/cli/test/providers.test.ts
@@ -39,6 +39,12 @@ for (const provider of availableProviders) {
     */
     continue;
   }
+  if (provider === 'jspm.io#system') {
+    // The ga.system.jspm.io CDN is deprecated and no longer receives new
+    // package builds, so any test depending on a package published after
+    // the deprecation will 404 the package config fetch.
+    continue;
+  }
 
   test(`Using provider: ${provider}`, async () => {
     let name = 'lit';
@@ -56,9 +62,7 @@ for (const provider of availableProviders) {
     if (!pjson.name) pjson.name = 'test-project';
     if (!pjson.exports) pjson.exports = { './index.js': './index.js' };
     if (!pjson.dependencies) pjson.dependencies = {};
-    // Pin lit to a version we know is mirrored across all providers (jspm.io
-    // can lag npm by a few minutes for newly published versions).
-    pjson.dependencies[name] = name === 'lit' ? '3.3.2' : '*';
+    pjson.dependencies[name] = '*';
     files.set('package.json', JSON.stringify(pjson, null, 2));
 
     // Add a test file that imports the module

--- a/cli/test/providers.test.ts
+++ b/cli/test/providers.test.ts
@@ -56,7 +56,9 @@ for (const provider of availableProviders) {
     if (!pjson.name) pjson.name = 'test-project';
     if (!pjson.exports) pjson.exports = { './index.js': './index.js' };
     if (!pjson.dependencies) pjson.dependencies = {};
-    pjson.dependencies[name] = '*';
+    // Pin lit to a version we know is mirrored across all providers (jspm.io
+    // can lag npm by a few minutes for newly published versions).
+    pjson.dependencies[name] = name === 'lit' ? '3.3.2' : '*';
     files.set('package.json', JSON.stringify(pjson, null, 2));
 
     // Add a test file that imports the module


### PR DESCRIPTION
Improves the `jspm serve` TypeScript dev-server experience: type-stripped output now ships a proper source map that pairs with the Chrome DevTools workspace folder integration added in #2730, so the canonical `.ts` URL binds to the on-disk file and edits in the debugger write through. Parse errors now surface as real `SyntaxError`s in the browser console, with the source snippet inlined and the stack frame mapped to the actual broken line.

**Summary**

- Replaces the `.ts.original` URL hack with an external `.ts.map` identity source map. Strip-only preserves lines, so the map is just an identity per line; works gracefully without DevTools (only fetched when opened).
- TS parse failures now emit a `2xx` JS stub that throws a `SyntaxError`. The throw is line-padded to the original error line and references the same `.ts.map`, so the browser console click lands on the broken source position in the workspace file.
- A best-effort regex extractor reads top-level export names from the broken source and re-declares them in the stub — otherwise importers fail link before the throw ever runs (`does not provide an export named X` would mask the real error).
- Install-side error printer downgrades non-`JspmError` exceptions to `e.message`, so Babel parse-error stack frames no longer spam the watch terminal on every save.

**Before / after — stripped TS output**

```js
// before
const strippedCode = transformSync(...).code;
const jsCode = `${strippedCode}\n//# sourceURL=${basename(filePath)}.original`;

// after
const strippedCode = transformSync(...).code;
const jsCode = `${strippedCode}\n//# sourceMappingURL=${basename(filePath)}.map`;
```

**Before / after — broken-TS browser console**

```
// before — 500, throw never runs, importer dies at link:
Uncaught SyntaxError: The requested module 'blob:...' does not provide an export named 'renderAerodrome'

// after — 200 stub, throw fires with snippet, stack links to renderer.ts:51:
Uncaught SyntaxError: Expression expected
  49 |     patches.fill();
  50 |   }
> 51 |   terrainLayer.addChild(patches);)
     |                                  ^
    at renderer.ts:51:1
```