### PR TITLE
fix: resolve #-prefixed inputMap specifiers in linked secondary scopes

### DIFF
--- a/generator/src/trace/tracemap.ts
+++ b/generator/src/trace/tracemap.ts
@@ -11,6 +11,7 @@ import {
   mergeConstraints,
   mergeLocks,
   extractLockConstraintsAndMap,
+  resolveScopeGroup,
   InstalledResolution
 } from '../install/lock.js';
 
@@ -739,6 +740,34 @@ export default class TraceMap {
           `${specifier} ${parentUrl} -> ${userImportsResolved} (scope resolution)`
         );
         return userImportsResolved;
+      }
+    }
+
+    // Linked scope fallback: if the parent is in a linked secondary scope,
+    // check the master scope's inputMap entries
+    if (this.opts.linkedScopes) {
+      const masterScope = resolveScopeGroup(parentPkgUrl, this.opts.linkedScopes);
+      if (masterScope !== parentPkgUrl) {
+        const masterScopeMatches = getScopeMatches(
+          masterScope, this.inputMap.scopes, this.inputMap.mapUrl!
+        );
+        for (const [scope] of masterScopeMatches) {
+          const mapMatch = getMapMatch(specifier, this.inputMap.scopes[scope]);
+          if (mapMatch) {
+            const resolved = await this.resolver.realPath(
+              resolveUrl(
+                this.inputMap.scopes[scope][mapMatch] + specifier.slice(mapMatch.length),
+                this.inputMap.mapUrl!,
+                this.inputMap.rootUrl!
+              )
+            );
+            this.log?.(
+              'tracemap/resolve',
+              `${specifier} ${parentUrl} -> ${resolved} (linked scope resolution)`
+            );
+            return resolved;
+          }
+        }
       }
     }
 

--- a/generator/test/api/linkedscopes.test.js
+++ b/generator/test/api/linkedscopes.test.js
@@ -112,6 +112,73 @@ import { Generator } from '@jspm/generator';
   assert.strictEqual(primarySemver, secondarySemver, 'both scopes should share the same resolution');
 }
 
+// #-prefixed inputMap specifiers resolve via linked master scope
+{
+  const CDN = 'https://example.com/modules';
+  const masterScope = `${CDN}/masterAAA/`;
+  const otherScope = `${CDN}/otherBBB/`;
+
+  const generator = new Generator({
+    mapUrl: 'about:blank',
+    inputMap: {
+      imports: {},
+      scopes: {
+        [masterScope]: {
+          '#framer/local/comp/abc/abc.js': `${CDN}/masterAAA/save1/mod.js`,
+          lodash: 'https://ga.jspm.io/npm:lodash@4.17.21/lodash.js',
+        },
+      },
+    },
+    env: ['production', 'browser', 'module'],
+    flattenScopes: false,
+    combineSubpaths: false,
+    scopedLink: true,
+    linkedScopes: {
+      [masterScope]: [masterScope, otherScope],
+    },
+    customProviders: {
+      test: {
+        ownsUrl(url) {
+          return url.startsWith(CDN + '/');
+        },
+        async getPackageConfig(url) {
+          if (!url.startsWith(CDN + '/')) return {};
+          const segments = url.slice(CDN.length + 1).split('/');
+          const moduleId = segments[0];
+          if (
+            (moduleId === 'masterAAA' || moduleId === 'otherBBB') &&
+            segments.length > 2
+          )
+            return null;
+          return {};
+        },
+      },
+    },
+  });
+
+  generator.setVirtualSourceData(`${CDN}/otherBBB/save1/`, {
+    'mod.js': 'import comp from "#framer/local/comp/abc/abc.js";\nexport default comp;',
+  });
+  generator.setVirtualSourceData(`${CDN}/masterAAA/save1/`, {
+    'mod.js': "export default 'A';",
+  });
+
+  await generator.link([`${CDN}/otherBBB/save1/mod.js`]);
+  const map = generator.getMap();
+
+  const otherScopeMappings = map.scopes[otherScope];
+  assert.ok(otherScopeMappings, 'otherBBB scope should exist in the output map');
+  assert.ok(
+    otherScopeMappings['#framer/local/comp/abc/abc.js'],
+    '#-prefixed specifier should be resolved for the linked secondary scope'
+  );
+  assert.strictEqual(
+    otherScopeMappings['#framer/local/comp/abc/abc.js'],
+    `${CDN}/masterAAA/save1/mod.js`,
+    '#-prefixed specifier should resolve to the master scope target'
+  );
+}
+
 // Freeze install preserves primary inputMap resolution despite secondary range conflict
 {
   const generator = new Generator({


### PR DESCRIPTION
When a module in a linked secondary scope imports a #-prefixed specifier (e.g. `#framer/local/comp/abc/abc.js`), the resolver was treating it as an npm package name and failing with "Unable to resolve npm:#framer@". The linkedScopes mechanism already handled regular bare specifiers via `resolveScopeGroup` in the installer, but the inputMap scope lookup in `resolve()` only matched scopes that are URL-prefixes of the parent URL — so a module in `otherBBB/` never found the `masterAAA/` scope entries.

The fix adds a fallback in `tracemap.ts`'s `resolve()` after the standard scope checks: if `linkedScopes` is configured and the parent package is in a secondary scope, use `resolveScopeGroup` to find the master scope and check its inputMap entries.

Before — the specifier falls through to the npm installer:

```ts
// Scope override
const userScopeMatch = scopeMatches.find(([, url]) => url === parentPkgUrl);
// ... no match for otherBBB -> falls through to parsePkg("#framer/...") -> npm install fails
```

After — linked scope entries are checked before falling through:

```ts
if (this.opts.linkedScopes) {
  const masterScope = resolveScopeGroup(parentPkgUrl, this.opts.linkedScopes);
  if (masterScope !== parentPkgUrl) {
    // check master scope inputMap entries
  }
}
```

Test added to `test/api/linkedscopes.test.js` using a custom provider with virtual source data — confirmed it fails without the fix and passes with it.