### PR TITLE
fix broken link to CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This monorepo includes the following tools:
 
 ### Documentation
 
-* JSPM CLI: https://jspm.org/docs/jspm-cli/
+* JSPM CLI: https://jspm.org/docs/cli/
 * JSPM Generator: https://jspm.org/docs/generator/
 * Import Map: https://jspm.org/docs/import-map/
 * Getting Started: https://jspm.org/getting-started


### PR DESCRIPTION
Hi all, thanks so much for JSPM and your work on advancing web standards.

The link to the CLI docs in README is broken. This updates with the correct link.

I searched through the code to make sure this was the only instance.

Thanks again.