### PR TITLE
Add moduleSkips and packageConfigSkips options to getCache

### DIFF
--- a/generator/src/generator.ts
+++ b/generator/src/generator.ts
@@ -1934,6 +1934,13 @@ export class Generator {
    * parse errors. CJS/TypeScript/System formats are excluded as they require
    * dynamic transpilation.
    *
+   * `packageConfigSkips` omits cached package configs and package bases for
+   * URLs starting with any listed base, while still caching their module
+   * analysis (deps). Use this for providers whose `getPackageConfig` is dynamic
+   * - caching a snapshot of such configs would pin stale package boundaries on
+   * subsequent runs. `moduleSkips` omits cached module analysis for URLs
+   * starting with any listed base.
+   *
    * @example
    * ```js
    * const generator = new Generator({ traceCache: true });
@@ -1942,9 +1949,15 @@ export class Generator {
    * fs.writeFileSync('cache.json', JSON.stringify(cache));
    * ```
    */
-  getCache(): GeneratorCache {
+  getCache({
+    moduleSkips = [],
+    packageConfigSkips = []
+  }: { moduleSkips?: string[]; packageConfigSkips?: string[] } = {}): GeneratorCache {
     const resolver = this.traceMap.resolver;
     const traceMap = this.traceMap;
+    const skipModule = (url: string) => moduleSkips.some(base => url.startsWith(base));
+    const skipPackageConfig = (url: string) =>
+      packageConfigSkips.some(base => url.startsWith(base));
     const packageConfigUrls = new Set([
       ...resolver.visitedUrls,
       ...resolver.touchedPackageConfigUrls
@@ -1958,6 +1971,7 @@ export class Generator {
     };
 
     for (const url of packageConfigUrls) {
+      if (skipPackageConfig(url)) continue;
       const pcfg = resolver.pcfgs[url];
       if (pcfg !== undefined) {
         cache.packageConfigs[url] = pcfg;
@@ -1967,9 +1981,11 @@ export class Generator {
     for (const url of analysisUrls) {
       const entry = resolver.traceEntries[url];
       const packageBase = resolver.packageBaseCache[url];
-      if (typeof packageBase === 'string') {
+      if (typeof packageBase === 'string' && !skipPackageConfig(url)) {
         cache.packageBases![url] = packageBase;
       }
+
+      if (skipModule(url)) continue;
 
       if (!entry) continue;
       if (entry.parseError) {

--- a/generator/test/api/getcache-skips.test.js
+++ b/generator/test/api/getcache-skips.test.js
@@ -1,0 +1,107 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+// getCache() supports skipping cache entries by URL base:
+//   packageConfigSkips - omit package configs and package bases (but keep
+//     module analysis) for providers whose getPackageConfig is dynamic, so a
+//     stale config snapshot can't pin package boundaries on later runs.
+//   moduleSkips - omit module analysis for the given bases.
+
+const HOST = 'https://framerusercontent.dev/modules/';
+const localUrl = `${HOST}local-project-id/local-save-id/LocalComponent.js`;
+const three178 = 'https://ga.jspm.io/npm:three@0.178.0/build/three.module.js';
+const threePcfg = {
+  name: 'three',
+  version: '0.178.0',
+  type: 'module',
+  main: './build/three.module.js',
+  exports: {
+    '.': { import: './build/three.module.js' },
+    './build/three.module.js': './build/three.module.js'
+  }
+};
+
+const generator = new Generator({
+  mapUrl: 'about:blank',
+  inputMap: {
+    imports: {},
+    scopes: {
+      [`${HOST}local-project-id/`]: {
+        '#framer/local/codeFile/LocalComponent.js': localUrl,
+        three: three178
+      }
+    }
+  },
+  env: ['production', 'browser', 'module'],
+  defaultProvider: 'jspm.io',
+  flattenScopes: false,
+  combineSubpaths: false,
+  scopedLink: true,
+  customProviders: {
+    framer: {
+      ownsUrl(url) {
+        return url.startsWith(HOST);
+      },
+      // Dynamic: deep save-id dirs of local modules are not package boundaries.
+      getPackageConfig(url) {
+        if (!url.startsWith(HOST)) return {};
+        const [moduleId, saveId, file] = url.slice(HOST.length).split('/');
+        if (moduleId === 'local-project-id' && file !== undefined && saveId !== undefined)
+          return null;
+        return { dependencies: {} };
+      }
+    }
+  },
+  traceCache: {
+    packageConfigs: { 'https://ga.jspm.io/npm:three@0.178.0/': threePcfg },
+    analysis: {
+      [localUrl]: {
+        deps: ['three'],
+        dynamicDeps: [],
+        size: 32,
+        integrity: '',
+        format: 'esm',
+        wasCjs: false
+      },
+      [three178]: {
+        deps: [],
+        dynamicDeps: [],
+        size: 10,
+        integrity: '',
+        format: 'esm',
+        wasCjs: false
+      }
+    },
+    packageBases: { [three178]: 'https://ga.jspm.io/npm:three@0.178.0/' }
+  }
+});
+
+await generator.link([localUrl]);
+
+const framerKeys = obj => Object.keys(obj || {}).filter(url => url.startsWith(HOST));
+
+// No skips: framer configs, bases and analysis are all cached.
+{
+  const cache = generator.getCache();
+  assert.ok(framerKeys(cache.packageConfigs).length > 0, 'framer configs cached by default');
+  assert.ok(framerKeys(cache.packageBases).length > 0, 'framer bases cached by default');
+  assert.ok(framerKeys(cache.analysis).length > 0, 'framer analysis cached by default');
+}
+
+// packageConfigSkips: framer configs and bases dropped, analysis retained.
+{
+  const cache = generator.getCache({ packageConfigSkips: [HOST] });
+  assert.strictEqual(framerKeys(cache.packageConfigs).length, 0, 'framer configs skipped');
+  assert.strictEqual(framerKeys(cache.packageBases).length, 0, 'framer bases skipped');
+  assert.ok(framerKeys(cache.analysis).length > 0, 'framer analysis retained');
+  // Non-framer entries are unaffected.
+  assert.ok(cache.packageConfigs['https://ga.jspm.io/npm:three@0.178.0/'], 'three config kept');
+}
+
+// moduleSkips: framer analysis dropped, configs and bases retained.
+{
+  const cache = generator.getCache({ moduleSkips: [HOST] });
+  assert.strictEqual(framerKeys(cache.analysis).length, 0, 'framer analysis skipped');
+  assert.ok(framerKeys(cache.packageConfigs).length > 0, 'framer configs retained');
+  assert.ok(framerKeys(cache.packageBases).length > 0, 'framer bases retained');
+}


### PR DESCRIPTION
getCache() can now omit cache entries by URL base, so a saved trace cache doesn't have to capture everything.

- packageConfigSkips omits cached package configs and package bases for the listed URL bases, while still caching their module analysis. This is for providers whose getPackageConfig is dynamic (e.g. a custom provider that decides package boundaries from external state): caching a snapshot of those configs pins stale package boundaries on subsequent runs, so a scope above the cached boundary stops participating in the lockfile and dependency versions collapse. Skipping them lets the provider recompute boundaries fresh each run while keeping dependency analysis cached.
- moduleSkips omits cached module analysis for the listed URL bases.
- No arguments preserves the previous behaviour exactly.

Includes a test covering all three cases against a dynamic custom provider.