### PR TITLE
fix: rollup build after upgrading from rollup@3

### DIFF
--- a/cli/chompfile.toml
+++ b/cli/chompfile.toml
@@ -67,7 +67,7 @@ deps = [
 run = """
 ../node_modules/.bin/esbuild src/cli.ts --bundle --platform=node --format=esm --outfile=$TARGET \
     --external:@jspm/generator --external:ora --external:picocolors --external:@babel/core \
-    --external:@jspm/plugin-rollup --external:node:*
+    --external:@jspm/plugin-rollup --external:rollup --external:@rollup/rollup-* --external:node:* --external:fsevents
 """
 
 [[task]]

--- a/cli/docs.md
+++ b/cli/docs.md
@@ -28,6 +28,8 @@ To customize the location of the output import map, the `--out` flag can be used
  
 ## Init
 
+▣  JSPM  -  Import Map Package Management
+
 **Usage**
   
 ```
@@ -58,6 +60,8 @@ jspm init ./my-project
 Initialize a project in the ./my-project directory.
 
 ## Ls
+
+▣  JSPM  -  Import Map Package Management
 
 **Usage**
   
@@ -124,6 +128,8 @@ List exports for the Lit package using the unpkg provider explicitly.
 
 ## Install
 
+▣  JSPM  -  Import Map Package Management
+
 **Usage**
   
 ```
@@ -174,6 +180,8 @@ Install packages into the import map tracing the package.json "exports" entry po
 jspm install
 ```
 ## Serve
+
+▣  JSPM  -  Import Map Package Management
 
 **Usage**
   
@@ -261,6 +269,8 @@ Start a server that does not generate the import map on startup, perform type st
 
 ## Build
 
+▣  JSPM  -  Import Map Package Management
+
 **Usage**
   
 ```
@@ -341,6 +351,8 @@ Build using a custom import map file.
 
 ## Publish
 
+▣  JSPM  -  Import Map Package Management
+
 **Usage**
   
 ```
@@ -351,7 +363,7 @@ Manages publishes to the JSPM providers, currently in experimental preview.
 WARNING: jspm publish is experimental and should only be used for prototyping.
 Unlike the https://ga.jspm.io/ CDN which is stable, reliability guarantees are
 not provided for publishing on https://jspm.io/. For reliable package delivery,
-use npm publish ΓÇö all npm packages are available on the https://ga.jspm.io/ CDN.
+use npm publish — all npm packages are available on the https://ga.jspm.io/ CDN.
 
 For publishing (default):
 
@@ -433,6 +445,8 @@ Download the application package foo@bar into the folder foo, merging its import
 
 ## Auth
 
+▣  JSPM  -  Import Map Package Management
+
 **Usage**
   
 ```
@@ -469,6 +483,8 @@ jspm auth
 List all available providers and their authentication status.
 
 ## Clear Cache
+
+▣  JSPM  -  Import Map Package Management
 
 **Usage**
   

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jspm",
   "type": "module",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Import Map Package Manager",
   "license": "Apache-2.0",
   "bin": {
@@ -20,7 +20,8 @@
     "@jspm/generator": "^2.16.0",
     "@jspm/plugin-rollup": "^3.0.0",
     "ora": "^9.4.0",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "rollup": "^4.60.4"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^9.0.0",
@@ -34,7 +35,6 @@
     "minimatch": "^10.0.1",
     "open": "^10.1.2",
     "prettier": "^3.8.3",
-    "rollup": "^4.60.4",
     "tinyspy": "^4.0.4",
     "typescript": "^5.9.3"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,14 +17,15 @@
     },
     "cli": {
       "name": "jspm",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.24.7",
         "@jspm/generator": "^2.16.0",
         "@jspm/plugin-rollup": "^3.0.0",
         "ora": "^9.4.0",
-        "picocolors": "^1.1.1"
+        "picocolors": "^1.1.1",
+        "rollup": "^4.60.4"
       },
       "bin": {
         "jspm": "dist/jspm.js"
@@ -41,7 +42,6 @@
         "minimatch": "^10.0.1",
         "open": "^10.1.2",
         "prettier": "^3.8.3",
-        "rollup": "^4.60.4",
         "tinyspy": "^4.0.4",
         "typescript": "^5.9.3"
       }
@@ -2219,7 +2219,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2233,7 +2232,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2247,7 +2245,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2261,7 +2258,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2275,7 +2271,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2289,7 +2284,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2303,7 +2297,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2317,7 +2310,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2331,7 +2323,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2345,7 +2336,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2359,7 +2349,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2373,7 +2362,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2387,7 +2375,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2401,7 +2388,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2415,7 +2401,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2429,7 +2414,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2443,7 +2427,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2457,7 +2440,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2471,7 +2453,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2485,7 +2466,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2499,7 +2479,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2513,7 +2492,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2527,7 +2505,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2541,7 +2518,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2555,7 +2531,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6430,7 +6405,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9433,7 +9407,6 @@
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
       "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -9478,7 +9451,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/run-applescript": {


### PR DESCRIPTION
fixes #2741

`rollup` switched to native binaries recently. And after recently when the cli move from `rollup@3` to `rollup@4`. It boke the cli. This PR fixes the cli dependencies.
If everything is good, post mergeing to `main`. We can make a release.