### PR TITLE
fix: reflect linked scope resolutions in the master scope

### DIFF
--- a/generator/src/trace/tracemap.ts
+++ b/generator/src/trace/tracemap.ts
@@ -374,6 +374,41 @@ export default class TraceMap {
     toplevel: boolean = true,
     parentUrl?: string
   ) {
+    const result = await this._extractMap(modules, integrity, toplevel, parentUrl);
+    this.applyLinkedScopes(result.map);
+    return result;
+  }
+
+  // Give every linked scope the same scope object identity as its master scope, so that a
+  // dependency resolved into any linked origin's scope is also reflected in the master scope
+  // (master wins on conflict). The installer already shares version resolution across a linked
+  // group; this mirrors that into the output map so the group resolves consistently and the
+  // master scope can be hoisted by a consumer. See the linkedScopes option.
+  private applyLinkedScopes(map: ImportMap) {
+    const linkedScopes = this.opts.linkedScopes;
+    if (!linkedScopes) return;
+    for (const [master, secondaries] of Object.entries(linkedScopes)) {
+      let shared = map.scopes[master];
+      for (const secondary of secondaries) {
+        if (secondary === master) continue;
+        const secondaryScope = map.scopes[secondary];
+        if (!secondaryScope || secondaryScope === shared) continue;
+        if (!shared) shared = map.scopes[master] = Object.create(null);
+        for (const key of Object.keys(secondaryScope)) {
+          if (!(key in shared)) shared[key] = secondaryScope[key];
+        }
+      }
+      if (!shared) continue;
+      for (const secondary of secondaries) map.scopes[secondary] = shared;
+    }
+  }
+
+  private async _extractMap(
+    modules: string[],
+    integrity: boolean,
+    toplevel: boolean = true,
+    parentUrl?: string
+  ) {
     this.log?.('generator/extractMap', `Extracting map for ${modules.join(', ')}`);
     const map = new ImportMap({ mapUrl: this.mapUrl, rootUrl: this.rootUrl });
 

--- a/generator/test/api/linkedscopes-promote.test.js
+++ b/generator/test/api/linkedscopes-promote.test.js
@@ -1,0 +1,77 @@
+import assert from 'assert';
+import { Generator } from '@jspm/generator';
+
+const CDN = 'https://example.com/modules';
+
+// Reduced repro of the FramerStudio import-map-generator-worker "local-project-pruning"
+// link fixture.
+//
+// A dependency imported only by a linked secondary origin (the master origin does not import
+// it) is seeded into the master scope - mirroring scopifyImportMap() moving a top-level
+// import into the master scope ahead of the generator run. After link() with scopedLink +
+// linkedScopes, the dependency should resolve into the master scope so that the consumer's
+// descopifyImportMap() can lift it back to top-level `imports`.
+//
+// The linkedScopes contract gives every linked scope the same scope-object identity as its
+// master, so the resolution is reflected in the master scope (hoistable by a consumer) while
+// the secondary scope keeps a consistent copy.
+{
+  const masterScope = `${CDN}/masterAAA/`; // e.g. the local "screen" module
+  const otherScope = `${CDN}/otherBBB/`; // e.g. the local "code file" module
+  const depUrl = `${CDN}/depMOD/save1/mod.js`;
+
+  const generator = new Generator({
+    mapUrl: 'about:blank',
+    inputMap: {
+      imports: {},
+      // scopifyImportMap moves the top-level `dep` import into the master scope.
+      scopes: { [masterScope]: { dep: depUrl } }
+    },
+    env: ['production', 'browser', 'module'],
+    flattenScopes: false,
+    combineSubpaths: false,
+    scopedLink: true,
+    linkedScopes: { [masterScope]: [masterScope, otherScope] },
+    customProviders: {
+      test: {
+        ownsUrl(url) {
+          return url.startsWith(CDN + '/');
+        },
+        async getPackageConfig(url) {
+          if (!url.startsWith(CDN + '/')) return {};
+          const segments = url.slice(CDN.length + 1).split('/');
+          const moduleId = segments[0];
+          // Local modules have their package boundary at `${CDN}/moduleId/` (no saveId).
+          if ((moduleId === 'masterAAA' || moduleId === 'otherBBB') && segments.length > 2)
+            return null;
+          return {};
+        }
+      }
+    }
+  });
+
+  // The master origin imports nothing; only the secondary code file imports `dep`.
+  generator.setVirtualSourceData(`${CDN}/masterAAA/save1/`, {
+    'mod.js': "export default 'screen';"
+  });
+  generator.setVirtualSourceData(`${CDN}/otherBBB/save1/`, {
+    'mod.js': 'import dep from "dep";\nexport default dep;'
+  });
+  generator.setVirtualSourceData(`${CDN}/depMOD/save1/`, { 'mod.js': 'export default 1;' });
+
+  await generator.link([`${CDN}/masterAAA/save1/mod.js`, `${CDN}/otherBBB/save1/mod.js`]);
+  const map = generator.getMap();
+
+  // The shared dependency is promoted into the master scope (hoistable to top-level imports
+  // by a descopify), even though the master origin never imported it.
+  assert.ok(
+    map.scopes?.[masterScope]?.dep,
+    `dep should resolve into the master scope ${masterScope}, got scopes: ${JSON.stringify(
+      map.scopes
+    )}`
+  );
+  assert.strictEqual(map.scopes[masterScope].dep, depUrl);
+
+  // The secondary keeps a consistent copy of the shared resolution.
+  assert.strictEqual(map.scopes[otherScope]?.dep, depUrl);
+}


### PR DESCRIPTION
`linkedScopes` makes a group of scope URLs share dependency resolution: during install/link a secondary scope resolves against the master scope's `package.json` ranges and shared locks, so every linked origin agrees on one version. That grouping governed version *selection*, but not where the resolution lands in the output map. `extractMap` keys each scoped mapping by the importing module's package base, so a dependency imported only by a linked *secondary* origin was written under that secondary's own scope and never appeared under the master scope. A consumer that hoists the master scope — for example to lift a shared resolution up to top-level imports — therefore lost it, and the master scope could be missing entirely when the master origin imported nothing of its own.

This mirrors the install-time grouping into the output map. After extraction, `applyLinkedScopes` gives every linked scope the master scope's object identity:

- merges each secondary scope's entries into the master scope, the master winning on conflict;
- injects the master scope even when the master origin imported nothing, so the shared resolution is always present there;
- points every linked scope key at that shared object, so the whole group resolves consistently.

It is a no-op when `linkedScopes` is unset, and runs as a generator op before flatten/combineSubpaths.

Before — master `masterAAA/` imports nothing, secondary `otherBBB/` imports `dep`:

```json
{
  "scopes": {
    "https://example.com/modules/otherBBB/": { "dep": ".../depMOD/save1/mod.js" }
  }
}
```

After:

```json
{
  "scopes": {
    "https://example.com/modules/masterAAA/": { "dep": ".../depMOD/save1/mod.js" },
    "https://example.com/modules/otherBBB/": { "dep": ".../depMOD/save1/mod.js" }
  }
}
```

Adds `test/api/linkedscopes-promote.test.js`, an offline virtual-source repro asserting that a dependency imported only by a linked secondary is promoted into the master scope while the secondary keeps a consistent copy. The full `test/api` suite (49 tests) passes, including the existing `linkedscopes.test.js` version-consistency cases.

Linked scope keys now all carry the group's shared resolutions (master-wins), so the output for a linked group is slightly larger — each scope key reflects the union — but every linked origin resolves identically and the master scope is always hoistable.
